### PR TITLE
add cwm.util module with navigation helpers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,9 +48,9 @@
 
   <modules>
     <module>model</module>
-<!-- <module>util</module>-->
-<!--    <module>instance</module>-->
-<!--    <module>documentation</module>-->
+    <module>util</module>
+    <!--    <module>instance</module>-->
+    <!--    <module>documentation</module>-->
   </modules>
 
   <dependencies>

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0"?>
+<!--
+/*********************************************************************
+* Copyright (c) 2026 Contributors to the Eclipse Foundation.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+**********************************************************************/
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.eclipse.daanse</groupId>
+    <artifactId>org.eclipse.daanse.cwm</artifactId>
+    <version>${revision}</version>
+  </parent>
+  <artifactId>org.eclipse.daanse.cwm.util</artifactId>
+  <name>Daanse CWM Util</name>
+  <description>Navigation and inspection helpers for the CWM relational model:
+    walking the namespace chain (Table → Schema → Catalog), finding primary
+    keys and foreign keys via back-references, extracting columns and
+    qualified names, and basic validity checks. Zero runtime dependencies
+    beyond the CWM model itself.</description>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.eclipse.daanse</groupId>
+      <artifactId>org.eclipse.daanse.cwm.model</artifactId>
+      <version>${project.version}</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.emf</groupId>
+      <artifactId>org.eclipse.emf.common</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.emf</groupId>
+      <artifactId>org.eclipse.emf.ecore</artifactId>
+      <scope>compile</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/util/src/main/java/org/eclipse/daanse/cwm/util/objectmodel/core/Classifiers.java
+++ b/util/src/main/java/org/eclipse/daanse/cwm/util/objectmodel/core/Classifiers.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   SmartCity Jena - initial
+ *   Stefan Bischof (bipolis.org) - initial
+ */
+package org.eclipse.daanse.cwm.util.objectmodel.core;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import org.eclipse.daanse.cwm.model.cwm.objectmodel.core.Classifier;
+import org.eclipse.daanse.cwm.model.cwm.objectmodel.core.Feature;
+
+/**
+ * Generic helpers over feature collections. The list overload covers feature
+ * lists exposed by non-{@link Classifier} types (e.g. {@code KeyRelationship},
+ * {@code UniqueKey}) that don't share a common Classifier ancestor.
+ */
+public final class Classifiers {
+
+    private Classifiers() {
+    }
+
+    /** Stream of {@code c.getFeature()} restricted to instances of {@code type}. */
+    public static <T extends Feature> Stream<T> featureStream(Classifier c, Class<T> type) {
+        return featureStream(c == null ? null : c.getFeature(), type);
+    }
+
+    /**
+     * Stream of {@code features} restricted to instances of {@code type}.
+     * Null-safe.
+     */
+    public static <T extends Feature> Stream<T> featureStream(List<? extends Feature> features, Class<T> type) {
+        if (features == null) {
+            return Stream.empty();
+        }
+        return features.stream().filter(type::isInstance).map(type::cast);
+    }
+
+    /** First feature of the given type with the given name; first match wins. */
+    public static <T extends Feature> Optional<T> findFeatureByName(Classifier c, Class<T> type, String name) {
+        if (c == null || type == null || name == null) {
+            return Optional.empty();
+        }
+        for (Feature f : c.getFeature()) {
+            if (type.isInstance(f) && name.equals(f.getName())) {
+                return Optional.of(type.cast(f));
+            }
+        }
+        return Optional.empty();
+    }
+}

--- a/util/src/main/java/org/eclipse/daanse/cwm/util/objectmodel/core/Features.java
+++ b/util/src/main/java/org/eclipse/daanse/cwm/util/objectmodel/core/Features.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   SmartCity Jena - initial
+ *   Stefan Bischof (bipolis.org) - initial
+ */
+package org.eclipse.daanse.cwm.util.objectmodel.core;
+
+import java.util.Optional;
+
+import org.eclipse.daanse.cwm.model.cwm.objectmodel.core.Classifier;
+import org.eclipse.daanse.cwm.model.cwm.objectmodel.core.Feature;
+
+public final class Features {
+
+    private Features() {
+    }
+
+    /** Owning {@link Classifier}, or empty if the feature is detached. */
+    public static Optional<Classifier> owner(Feature f) {
+        return f == null ? Optional.empty() : Optional.ofNullable(f.getOwner());
+    }
+}

--- a/util/src/main/java/org/eclipse/daanse/cwm/util/objectmodel/core/Namespaces.java
+++ b/util/src/main/java/org/eclipse/daanse/cwm/util/objectmodel/core/Namespaces.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   SmartCity Jena - initial
+ *   Stefan Bischof (bipolis.org) - initial
+ */
+package org.eclipse.daanse.cwm.util.objectmodel.core;
+
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import org.eclipse.daanse.cwm.model.cwm.objectmodel.core.ModelElement;
+import org.eclipse.daanse.cwm.model.cwm.objectmodel.core.Namespace;
+
+public final class Namespaces {
+
+    private Namespaces() {
+    }
+
+    /**
+     * First ancestor (inclusive) of type {@code T} reached via
+     * {@code getNamespace()}.
+     */
+    public static <T extends Namespace> Optional<T> walkUpTo(Namespace start, Class<T> type) {
+        Namespace ns = start;
+        while (ns != null) {
+            if (type.isInstance(ns)) {
+                return Optional.of(type.cast(ns));
+            }
+            ns = ns.getNamespace();
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Stream of {@code ns.getOwnedElement()} restricted to instances of
+     * {@code type}.
+     */
+    public static <T extends ModelElement> Stream<T> ownedElementStream(Namespace ns, Class<T> type) {
+        if (ns == null) {
+            return Stream.empty();
+        }
+        return ns.getOwnedElement().stream().filter(type::isInstance).map(type::cast);
+    }
+
+    /**
+     * First owned element of the given type with the given name; first match wins.
+     */
+    public static <T extends ModelElement> Optional<T> findOwnedByName(Namespace ns, Class<T> type, String name) {
+        if (ns == null || type == null || name == null) {
+            return Optional.empty();
+        }
+        for (ModelElement me : ns.getOwnedElement()) {
+            if (type.isInstance(me) && name.equals(me.getName())) {
+                return Optional.of(type.cast(me));
+            }
+        }
+        return Optional.empty();
+    }
+}

--- a/util/src/main/java/org/eclipse/daanse/cwm/util/objectmodel/core/package-info.java
+++ b/util/src/main/java/org/eclipse/daanse/cwm/util/objectmodel/core/package-info.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+@org.osgi.annotation.bundle.Export
+@org.osgi.annotation.versioning.Version("0.0.1")
+package org.eclipse.daanse.cwm.util.objectmodel.core;

--- a/util/src/main/java/org/eclipse/daanse/cwm/util/objectmodel/instance/DataSlots.java
+++ b/util/src/main/java/org/eclipse/daanse/cwm/util/objectmodel/instance/DataSlots.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   SmartCity Jena - initial
+ *   Stefan Bischof (bipolis.org) - initial
+ */
+package org.eclipse.daanse.cwm.util.objectmodel.instance;
+
+import java.util.Optional;
+
+import org.eclipse.daanse.cwm.model.cwm.objectmodel.instance.DataSlot;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.Column;
+
+public final class DataSlots {
+
+    private DataSlots() {
+    }
+
+    /**
+     * {@link Column} the slot is bound to, or empty if the feature is missing or
+     * not a column.
+     */
+    public static Optional<Column> column(DataSlot slot) {
+        if (slot == null || slot.getFeature() == null) {
+            return Optional.empty();
+        }
+        if (slot.getFeature() instanceof Column c) {
+            return Optional.of(c);
+        }
+        return Optional.empty();
+    }
+
+    /** String literal carried by the slot, null-safe. */
+    public static String dataValue(DataSlot slot) {
+        return slot == null ? null : slot.getDataValue();
+    }
+}

--- a/util/src/main/java/org/eclipse/daanse/cwm/util/objectmodel/instance/package-info.java
+++ b/util/src/main/java/org/eclipse/daanse/cwm/util/objectmodel/instance/package-info.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+@org.osgi.annotation.bundle.Export
+@org.osgi.annotation.versioning.Version("0.0.1")
+package org.eclipse.daanse.cwm.util.objectmodel.instance;

--- a/util/src/main/java/org/eclipse/daanse/cwm/util/resource/relational/Catalogs.java
+++ b/util/src/main/java/org/eclipse/daanse/cwm/util/resource/relational/Catalogs.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   SmartCity Jena - initial
+ *   Stefan Bischof (bipolis.org) - initial
+ */
+package org.eclipse.daanse.cwm.util.resource.relational;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import org.eclipse.daanse.cwm.model.cwm.objectmodel.core.ModelElement;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.Catalog;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.Schema;
+import org.eclipse.daanse.cwm.util.objectmodel.core.Namespaces;
+
+public final class Catalogs {
+
+    private Catalogs() {
+    }
+
+    /** Schemas directly owned by {@code catalog}. */
+    public static List<Schema> schemas(Catalog catalog) {
+        return schemaStream(catalog).toList();
+    }
+
+    /** Stream of schemas directly owned by {@code catalog}. */
+    public static Stream<Schema> schemaStream(Catalog catalog) {
+        return Namespaces.ownedElementStream(catalog, Schema.class);
+    }
+
+    /** Find an owned schema by name. */
+    public static Optional<Schema> findSchema(Catalog catalog, String name) {
+        return findOwnedByName(catalog, Schema.class, name);
+    }
+
+    /** First owned element of the given type with the given name. */
+    public static <T extends ModelElement> Optional<T> findOwnedByName(Catalog catalog, Class<T> type, String name) {
+        return Namespaces.findOwnedByName(catalog, type, name);
+    }
+}

--- a/util/src/main/java/org/eclipse/daanse/cwm/util/resource/relational/ColumnSets.java
+++ b/util/src/main/java/org/eclipse/daanse/cwm/util/resource/relational/ColumnSets.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   SmartCity Jena - initial
+ *   Stefan Bischof (bipolis.org) - initial
+ */
+package org.eclipse.daanse.cwm.util.resource.relational;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.Column;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.ColumnSet;
+import org.eclipse.daanse.cwm.util.objectmodel.core.Classifiers;
+
+public final class ColumnSets {
+
+    private ColumnSets() {
+    }
+
+    /** Columns of the set in declaration order. */
+    public static List<Column> columns(ColumnSet columnSet) {
+        return columnStream(columnSet).toList();
+    }
+
+    /** Stream of columns in declaration order. */
+    public static Stream<Column> columnStream(ColumnSet columnSet) {
+        return Classifiers.featureStream(columnSet, Column.class);
+    }
+
+    /** Lookup a column by name (case-sensitive). */
+    public static Optional<Column> findColumn(ColumnSet columnSet, String name) {
+        return Classifiers.findFeatureByName(columnSet, Column.class, name);
+    }
+}

--- a/util/src/main/java/org/eclipse/daanse/cwm/util/resource/relational/Columns.java
+++ b/util/src/main/java/org/eclipse/daanse/cwm/util/resource/relational/Columns.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   SmartCity Jena - initial
+ *   Stefan Bischof (bipolis.org) - initial
+ */
+package org.eclipse.daanse.cwm.util.resource.relational;
+
+import java.util.Optional;
+
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.Column;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.ColumnSet;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.NamedColumnSet;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.Table;
+
+public final class Columns {
+
+    private Columns() {
+    }
+
+    /** Owning {@link ColumnSet}, or empty if detached. */
+    public static Optional<ColumnSet> owner(Column column) {
+        if (column == null || column.getOwner() == null) {
+            return Optional.empty();
+        }
+        return column.getOwner() instanceof ColumnSet cs ? Optional.of(cs) : Optional.empty();
+    }
+
+    /**
+     * Owning {@link NamedColumnSet} (Table or View), or empty for a bare ColumnSet
+     * (e.g. InlineTable).
+     */
+    public static Optional<NamedColumnSet> namedOwner(Column column) {
+        return owner(column).filter(NamedColumnSet.class::isInstance).map(NamedColumnSet.class::cast);
+    }
+
+    /** Owning {@link Table}, or empty when the owner is a View or non-Table set. */
+    public static Optional<Table> tableOwner(Column column) {
+        return owner(column).filter(Table.class::isInstance).map(Table.class::cast);
+    }
+
+    /**
+     * Dotted identifier {@code "catalog.schema.table.column"}. Missing ancestors
+     * are omitted. Display/logging format — no dialect quoting.
+     */
+    public static String qualifiedName(Column column) {
+        if (column == null) {
+            return null;
+        }
+        Optional<NamedColumnSet> ncs = namedOwner(column);
+        if (ncs.isEmpty()) {
+            return column.getName();
+        }
+        return NamedColumnSets.qualifiedName(ncs.get()) + "." + column.getName();
+    }
+
+    /** Non-null and has a non-blank name. */
+    public static boolean isValid(Column column) {
+        return column != null && column.getName() != null && !column.getName().isBlank();
+    }
+}

--- a/util/src/main/java/org/eclipse/daanse/cwm/util/resource/relational/ForeignKeys.java
+++ b/util/src/main/java/org/eclipse/daanse/cwm/util/resource/relational/ForeignKeys.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   SmartCity Jena - initial
+ *   Stefan Bischof (bipolis.org) - initial
+ */
+package org.eclipse.daanse.cwm.util.resource.relational;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import org.eclipse.daanse.cwm.model.cwm.foundation.keysindexes.UniqueKey;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.Column;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.ForeignKey;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.Table;
+import org.eclipse.daanse.cwm.util.objectmodel.core.Classifiers;
+
+public final class ForeignKeys {
+
+    private ForeignKeys() {
+    }
+
+    /** Columns participating in the foreign key, in declared order. */
+    public static List<Column> columns(ForeignKey fk) {
+        return columnStream(fk).toList();
+    }
+
+    /** Stream of FK columns. */
+    public static Stream<Column> columnStream(ForeignKey fk) {
+        return Classifiers.featureStream(fk == null ? null : fk.getFeature(), Column.class);
+    }
+
+    /** Referenced unique key (PK or UK on the parent table). */
+    public static Optional<UniqueKey> targetUniqueKey(ForeignKey fk) {
+        return fk == null ? Optional.empty() : Optional.ofNullable(fk.getUniqueKey());
+    }
+
+    /** Parent table of the referenced unique key, via a target column's owner. */
+    public static Optional<Table> targetTable(ForeignKey fk) {
+        return targetUniqueKey(fk).flatMap(uk -> Classifiers.featureStream(uk.getFeature(), Column.class).findFirst())
+                .flatMap(Columns::tableOwner);
+    }
+}

--- a/util/src/main/java/org/eclipse/daanse/cwm/util/resource/relational/NamedColumnSets.java
+++ b/util/src/main/java/org/eclipse/daanse/cwm/util/resource/relational/NamedColumnSets.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   SmartCity Jena - initial
+ *   Stefan Bischof (bipolis.org) - initial
+ */
+package org.eclipse.daanse.cwm.util.resource.relational;
+
+import java.util.Optional;
+
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.Catalog;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.NamedColumnSet;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.Schema;
+import org.eclipse.daanse.cwm.util.objectmodel.core.Namespaces;
+
+/**
+ * Helpers specific to {@link NamedColumnSet}. For column accessors use
+ * {@link ColumnSets} — they apply to every {@code ColumnSet} subtype.
+ */
+public final class NamedColumnSets {
+
+    private NamedColumnSets() {
+    }
+
+    /**
+     * First enclosing {@link Schema} reached via {@code getNamespace()}, or empty
+     * if detached.
+     */
+    public static Optional<Schema> findSchema(NamedColumnSet columnSet) {
+        return columnSet == null ? Optional.empty() : Namespaces.walkUpTo(columnSet.getNamespace(), Schema.class);
+    }
+
+    /**
+     * Enclosing {@link Catalog} via the schema level; empty if either ancestor is
+     * missing.
+     */
+    public static Optional<Catalog> findCatalog(NamedColumnSet columnSet) {
+        return findSchema(columnSet).flatMap(Schemas::findCatalog);
+    }
+
+    /**
+     * Dotted identifier {@code "catalog.schema.table"}. Missing ancestors are
+     * omitted. Display/logging format — no dialect quoting.
+     */
+    public static String qualifiedName(NamedColumnSet columnSet) {
+        if (columnSet == null) {
+            return null;
+        }
+        Optional<Schema> schema = findSchema(columnSet);
+        Optional<Catalog> catalog = schema.flatMap(Schemas::findCatalog);
+        StringBuilder sb = new StringBuilder();
+        catalog.ifPresent(c -> sb.append(c.getName()).append('.'));
+        schema.ifPresent(s -> sb.append(s.getName()).append('.'));
+        sb.append(columnSet.getName());
+        return sb.toString();
+    }
+}

--- a/util/src/main/java/org/eclipse/daanse/cwm/util/resource/relational/PrimaryKeys.java
+++ b/util/src/main/java/org/eclipse/daanse/cwm/util/resource/relational/PrimaryKeys.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   SmartCity Jena - initial
+ *   Stefan Bischof (bipolis.org) - initial
+ */
+package org.eclipse.daanse.cwm.util.resource.relational;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.Column;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.PrimaryKey;
+import org.eclipse.daanse.cwm.util.objectmodel.core.Classifiers;
+
+public final class PrimaryKeys {
+
+    private PrimaryKeys() {
+    }
+
+    /** Columns that make up the primary key, in declared order. */
+    public static List<Column> columns(PrimaryKey pk) {
+        return columnStream(pk).toList();
+    }
+
+    /** Stream of columns of the primary key. */
+    public static Stream<Column> columnStream(PrimaryKey pk) {
+        return Classifiers.featureStream(pk == null ? null : pk.getFeature(), Column.class);
+    }
+}

--- a/util/src/main/java/org/eclipse/daanse/cwm/util/resource/relational/RowSets.java
+++ b/util/src/main/java/org/eclipse/daanse/cwm/util/resource/relational/RowSets.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   SmartCity Jena - initial
+ *   Stefan Bischof (bipolis.org) - initial
+ */
+package org.eclipse.daanse.cwm.util.resource.relational;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.Row;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.RowSet;
+import org.eclipse.daanse.cwm.util.objectmodel.core.Namespaces;
+
+public final class RowSets {
+
+    private RowSets() {
+    }
+
+    /** Rows of the row set, in declaration order. */
+    public static List<Row> rows(RowSet rowSet) {
+        return rowStream(rowSet).toList();
+    }
+
+    /** Stream of rows of the row set. */
+    public static Stream<Row> rowStream(RowSet rowSet) {
+        return Namespaces.ownedElementStream(rowSet, Row.class);
+    }
+}

--- a/util/src/main/java/org/eclipse/daanse/cwm/util/resource/relational/Rows.java
+++ b/util/src/main/java/org/eclipse/daanse/cwm/util/resource/relational/Rows.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   SmartCity Jena - initial
+ *   Stefan Bischof (bipolis.org) - initial
+ */
+package org.eclipse.daanse.cwm.util.resource.relational;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import org.eclipse.daanse.cwm.model.cwm.objectmodel.instance.DataSlot;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.Column;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.Row;
+
+public final class Rows {
+
+    private Rows() {
+    }
+
+    /** All {@link DataSlot}s attached to this row, in declaration order. */
+    public static List<DataSlot> slots(Row row) {
+        return slotStream(row).toList();
+    }
+
+    /** Stream of {@link DataSlot}s attached to this row. */
+    public static Stream<DataSlot> slotStream(Row row) {
+        if (row == null) {
+            return Stream.empty();
+        }
+        return row.getSlot().stream().filter(DataSlot.class::isInstance).map(DataSlot.class::cast);
+    }
+
+    /**
+     * Literal value of the slot bound to {@code column}, or empty if no such slot.
+     */
+    public static Optional<String> valueOf(Row row, Column column) {
+        if (row == null || column == null) {
+            return Optional.empty();
+        }
+        for (DataSlot ds : slots(row)) {
+            if (ds.getFeature() == column) {
+                return Optional.ofNullable(ds.getDataValue());
+            }
+        }
+        return Optional.empty();
+    }
+}

--- a/util/src/main/java/org/eclipse/daanse/cwm/util/resource/relational/Schemas.java
+++ b/util/src/main/java/org/eclipse/daanse/cwm/util/resource/relational/Schemas.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   SmartCity Jena - initial
+ *   Stefan Bischof (bipolis.org) - initial
+ */
+package org.eclipse.daanse.cwm.util.resource.relational;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import org.eclipse.daanse.cwm.model.cwm.objectmodel.core.ModelElement;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.Catalog;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.NamedColumnSet;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.Schema;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.Table;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.View;
+import org.eclipse.daanse.cwm.util.objectmodel.core.Namespaces;
+
+public final class Schemas {
+
+    private Schemas() {
+    }
+
+    /** Tables directly owned by {@code schema}. */
+    public static List<Table> tables(Schema schema) {
+        return tableStream(schema).toList();
+    }
+
+    /** Stream of tables directly owned by {@code schema}. */
+    public static Stream<Table> tableStream(Schema schema) {
+        return Namespaces.ownedElementStream(schema, Table.class);
+    }
+
+    /** Views directly owned by {@code schema}. */
+    public static List<View> views(Schema schema) {
+        return viewStream(schema).toList();
+    }
+
+    /** Stream of views directly owned by {@code schema}. */
+    public static Stream<View> viewStream(Schema schema) {
+        return Namespaces.ownedElementStream(schema, View.class);
+    }
+
+    /** All named column sets (tables + views) directly owned by {@code schema}. */
+    public static List<NamedColumnSet> columnSets(Schema schema) {
+        return columnSetStream(schema).toList();
+    }
+
+    /** Stream of named column sets directly owned by {@code schema}. */
+    public static Stream<NamedColumnSet> columnSetStream(Schema schema) {
+        return Namespaces.ownedElementStream(schema, NamedColumnSet.class);
+    }
+
+    /** Find an owned table by name. */
+    public static Optional<Table> findTable(Schema schema, String name) {
+        return Namespaces.findOwnedByName(schema, Table.class, name);
+    }
+
+    /** Find an owned view by name. */
+    public static Optional<View> findView(Schema schema, String name) {
+        return Namespaces.findOwnedByName(schema, View.class, name);
+    }
+
+    /** First owned element with the given name (any type). First match wins. */
+    public static Optional<ModelElement> findOwnedByName(Schema schema, String name) {
+        return Namespaces.findOwnedByName(schema, ModelElement.class, name);
+    }
+
+    /**
+     * Enclosing {@link Catalog} reached via the namespace chain, or empty if
+     * detached.
+     */
+    public static Optional<Catalog> findCatalog(Schema schema) {
+        return schema == null ? Optional.empty() : Namespaces.walkUpTo(schema.getNamespace(), Catalog.class);
+    }
+
+    /** First owned element of the given type with the given name. */
+    public static <T extends ModelElement> Optional<T> findOwnedByName(Schema schema, Class<T> type, String name) {
+        return Namespaces.findOwnedByName(schema, type, name);
+    }
+
+    /** Dotted identifier {@code "catalog.schema"}; missing catalog is omitted. */
+    public static String qualifiedName(Schema schema) {
+        if (schema == null) {
+            return null;
+        }
+        Optional<Catalog> catalog = findCatalog(schema);
+        return catalog.map(c -> c.getName() + "." + schema.getName()).orElse(schema.getName());
+    }
+}

--- a/util/src/main/java/org/eclipse/daanse/cwm/util/resource/relational/SqlSimpleTypes.java
+++ b/util/src/main/java/org/eclipse/daanse/cwm/util/resource/relational/SqlSimpleTypes.java
@@ -1,0 +1,401 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   SmartCity Jena - initial
+ *   Stefan Bischof (bipolis.org) - initial
+ */
+package org.eclipse.daanse.cwm.util.resource.relational;
+
+import java.sql.Types;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.SQLSimpleType;
+import org.eclipse.emf.ecore.util.EcoreUtil;
+
+/**
+ * Factories and inspection helpers for {@link SQLSimpleType}. SQL-99 spec types
+ * live on the nested {@link Sql99} class. Every factory method ends in
+ * {@code Type} and emits a fresh instance.
+ */
+public final class SqlSimpleTypes {
+
+    private SqlSimpleTypes() {
+    }
+
+    /** {@code VARCHAR(length)}. */
+    public static SQLSimpleType varcharType(int length) {
+        SQLSimpleType t = Sql99.characterVaryingType();
+        t.setCharacterMaximumLength(length);
+        return t;
+    }
+
+    /** {@code NVARCHAR(length)}. */
+    public static SQLSimpleType nvarcharType(int length) {
+        SQLSimpleType t = Sql99.nationalCharacterVaryingType();
+        t.setCharacterMaximumLength(length);
+        return t;
+    }
+
+    /** {@code CHARACTER(length)}. */
+    public static SQLSimpleType characterType(int length) {
+        SQLSimpleType t = Sql99.characterType();
+        t.setCharacterMaximumLength(length);
+        return t;
+    }
+
+    /** {@code NCHAR(length)}. */
+    public static SQLSimpleType nationalCharacterType(int length) {
+        SQLSimpleType t = Sql99.nationalCharacterType();
+        t.setCharacterMaximumLength(length);
+        return t;
+    }
+
+    /** {@code DECIMAL(precision, scale)}. */
+    public static SQLSimpleType decimalType(int precision, int scale) {
+        SQLSimpleType t = Sql99.decimalType();
+        t.setNumericPrecision(precision);
+        t.setNumericScale(scale);
+        return t;
+    }
+
+    /** {@code NUMERIC(precision, scale)}. */
+    public static SQLSimpleType numericType(int precision, int scale) {
+        SQLSimpleType t = Sql99.numericType();
+        t.setNumericPrecision(precision);
+        t.setNumericScale(scale);
+        return t;
+    }
+
+    /** {@code FLOAT(precision)} — precision in bits. */
+    public static SQLSimpleType floatType(int precision) {
+        SQLSimpleType t = Sql99.floatType();
+        t.setNumericPrecision(precision);
+        return t;
+    }
+
+    private static final SQLSimpleType BIGINT_T = Templates.integral("BIGINT", Types.BIGINT);
+    private static final SQLSimpleType TINYINT_T = Templates.integral("TINYINT", Types.TINYINT);
+
+    public static SQLSimpleType bigintType() {
+        return EcoreUtil.copy(BIGINT_T);
+    }
+
+    public static SQLSimpleType tinyintType() {
+        return EcoreUtil.copy(TINYINT_T);
+    }
+
+    /** Resolve a type by SQL-99 name (case-insensitive, whitespace collapsed). */
+    public static Optional<SQLSimpleType> byName(String name) {
+        if (name == null) {
+            return Optional.empty();
+        }
+        String key = name.trim().toUpperCase().replaceAll("\\s+", " ");
+        Supplier<SQLSimpleType> s = BY_NAME.get(key);
+        return s == null ? Optional.empty() : Optional.of(s.get());
+    }
+
+    private static final Map<String, Supplier<SQLSimpleType>> BY_NAME = byNameMap();
+
+    private static Map<String, Supplier<SQLSimpleType>> byNameMap() {
+        Map<String, Supplier<SQLSimpleType>> m = new LinkedHashMap<>();
+        m.put("BIT", Sql99::bitType);
+        m.put("BIT VARYING", Sql99::bitVaryingType);
+        m.put("BINARY LARGE OBJECT", Sql99::binaryLargeObjectType);
+        m.put("CHARACTER", Sql99::characterType);
+        m.put("CHARACTER VARYING", Sql99::characterVaryingType);
+        m.put("CHARACTER LARGE OBJECT", Sql99::characterLargeObjectType);
+        m.put("NATIONAL CHARACTER", Sql99::nationalCharacterType);
+        m.put("NATIONAL CHARACTER VARYING", Sql99::nationalCharacterVaryingType);
+        m.put("NATIONAL CHARACTER LARGE OBJECT", Sql99::nationalCharacterLargeObjectType);
+        m.put("NUMERIC", Sql99::numericType);
+        m.put("DECIMAL", Sql99::decimalType);
+        m.put("INTEGER", Sql99::integerType);
+        m.put("SMALLINT", Sql99::smallintType);
+        m.put("FLOAT", Sql99::floatType);
+        m.put("REAL", Sql99::realType);
+        m.put("DOUBLE PRECISION", Sql99::doublePrecisionType);
+        m.put("BOOLEAN", Sql99::booleanType);
+        m.put("DATE", Sql99::dateType);
+        m.put("TIME", Sql99::timeType);
+        m.put("TIME WITH TIMEZONE", Sql99::timeWithTimezoneType);
+        m.put("TIMESTAMP", Sql99::timestampType);
+        m.put("TIMESTAMP WITH TIMEZONE", Sql99::timestampWithTimezoneType);
+        m.put("INTERVAL", Sql99::intervalType);
+        m.put("BIGINT", SqlSimpleTypes::bigintType);
+        m.put("TINYINT", SqlSimpleTypes::tinyintType);
+        m.put("BLOB", Sql99::blobType);
+        m.put("CLOB", Sql99::clobType);
+        m.put("NCLOB", Sql99::nclobType);
+        m.put("CHAR", Sql99::characterType);
+        m.put("VARCHAR", Sql99::varcharType);
+        m.put("NCHAR", Sql99::nationalCharacterType);
+        m.put("NVARCHAR", Sql99::nationalCharacterVaryingType);
+        m.put("INT", Sql99::integerType);
+        return m;
+    }
+
+    /** JDBC type code, or {@link Types#OTHER} when null. */
+    public static int jdbcType(SQLSimpleType type) {
+        return type == null ? Types.OTHER : (int) type.getTypeNumber();
+    }
+
+    public static boolean isNumeric(SQLSimpleType type) {
+        switch (jdbcType(type)) {
+        case Types.TINYINT:
+        case Types.SMALLINT:
+        case Types.INTEGER:
+        case Types.BIGINT:
+        case Types.REAL:
+        case Types.FLOAT:
+        case Types.DOUBLE:
+        case Types.DECIMAL:
+        case Types.NUMERIC:
+            return true;
+        default:
+            return false;
+        }
+    }
+
+    public static boolean isText(SQLSimpleType type) {
+        switch (jdbcType(type)) {
+        case Types.CHAR:
+        case Types.VARCHAR:
+        case Types.LONGVARCHAR:
+        case Types.NCHAR:
+        case Types.NVARCHAR:
+        case Types.LONGNVARCHAR:
+        case Types.CLOB:
+        case Types.NCLOB:
+            return true;
+        default:
+            return false;
+        }
+    }
+
+    public static boolean isTemporal(SQLSimpleType type) {
+        switch (jdbcType(type)) {
+        case Types.DATE:
+        case Types.TIME:
+        case Types.TIMESTAMP:
+        case Types.TIME_WITH_TIMEZONE:
+        case Types.TIMESTAMP_WITH_TIMEZONE:
+            return true;
+        default:
+            return false;
+        }
+    }
+
+    /** Short form like {@code "VARCHAR(255)"} or {@code "DECIMAL(10,2)"}. */
+    public static String describe(SQLSimpleType type) {
+        if (type == null) {
+            return null;
+        }
+        String name = type.getName();
+        if (isNumeric(type) && type.getNumericPrecision() > 0) {
+            if (type.getNumericScale() > 0) {
+                return name + "(" + type.getNumericPrecision() + "," + type.getNumericScale() + ")";
+            }
+            return name + "(" + type.getNumericPrecision() + ")";
+        }
+        if (isText(type) && type.getCharacterMaximumLength() > 0) {
+            return name + "(" + type.getCharacterMaximumLength() + ")";
+        }
+        return name;
+    }
+
+    /** Factories for the SQL-99 §19.5 data types. */
+    public static final class Sql99 {
+
+        private static final SQLSimpleType BIT = Templates.bare("BIT", Types.BIT);
+        private static final SQLSimpleType BIT_VARYING = Templates.bare("BIT VARYING", Types.VARBINARY);
+        private static final SQLSimpleType BINARY_LARGE_OBJECT = Templates.bare("BINARY LARGE OBJECT", Types.BLOB);
+        private static final SQLSimpleType CHARACTER = Templates.bare("CHARACTER", Types.CHAR);
+        private static final SQLSimpleType CHARACTER_VARYING = Templates.bare("CHARACTER VARYING", Types.VARCHAR);
+        private static final SQLSimpleType CHARACTER_LARGE_OBJECT = Templates.bare("CHARACTER LARGE OBJECT",
+                Types.CLOB);
+        private static final SQLSimpleType NATIONAL_CHARACTER = Templates.bare("NATIONAL CHARACTER", Types.NCHAR);
+        private static final SQLSimpleType NATIONAL_CHARACTER_VARYING = Templates.bare("NATIONAL CHARACTER VARYING",
+                Types.NVARCHAR);
+        private static final SQLSimpleType NATIONAL_CHARACTER_LARGE_OBJECT = Templates
+                .bare("NATIONAL CHARACTER LARGE OBJECT", Types.NCLOB);
+
+        // Numeric
+        private static final SQLSimpleType NUMERIC = Templates.numericRadix("NUMERIC", Types.NUMERIC, 10);
+        private static final SQLSimpleType DECIMAL = Templates.numericRadix("DECIMAL", Types.DECIMAL, 10);
+        private static final SQLSimpleType INTEGER = Templates.integral("INTEGER", Types.INTEGER);
+        private static final SQLSimpleType SMALLINT = Templates.integral("SMALLINT", Types.SMALLINT);
+        private static final SQLSimpleType FLOAT = Templates.numericRadix("FLOAT", Types.FLOAT, 2);
+        private static final SQLSimpleType REAL = Templates.numericRadix("REAL", Types.REAL, 2);
+        private static final SQLSimpleType DOUBLE_PRECISION = Templates.numericRadix("DOUBLE PRECISION", Types.DOUBLE,
+                2);
+        // Boolean
+        private static final SQLSimpleType BOOLEAN = Templates.bare("BOOLEAN", Types.BOOLEAN);
+
+        // Date and time
+        private static final SQLSimpleType DATE = Templates.bare("DATE", Types.DATE);
+        private static final SQLSimpleType TIME = Templates.bare("TIME", Types.TIME);
+        private static final SQLSimpleType TIME_WITH_TIMEZONE = Templates.bare("TIME WITH TIMEZONE",
+                Types.TIME_WITH_TIMEZONE);
+        private static final SQLSimpleType TIMESTAMP = Templates.bare("TIMESTAMP", Types.TIMESTAMP);
+        private static final SQLSimpleType TIMESTAMP_WITH_TIMEZONE = Templates.bare("TIMESTAMP WITH TIMEZONE",
+                Types.TIMESTAMP_WITH_TIMEZONE);
+        private static final SQLSimpleType INTERVAL = Templates.bare("INTERVAL", Types.OTHER);
+
+        private Sql99() {
+        }
+
+        public static SQLSimpleType bitType() {
+            return EcoreUtil.copy(BIT);
+        }
+
+        public static SQLSimpleType bitVaryingType() {
+            return EcoreUtil.copy(BIT_VARYING);
+        }
+
+        public static SQLSimpleType binaryLargeObjectType() {
+            return EcoreUtil.copy(BINARY_LARGE_OBJECT);
+        }
+
+        /** Alias for {@link #binaryLargeObjectType()}. */
+        public static SQLSimpleType blobType() {
+            return binaryLargeObjectType();
+        }
+
+        public static SQLSimpleType characterType() {
+            return EcoreUtil.copy(CHARACTER);
+        }
+
+        public static SQLSimpleType characterVaryingType() {
+            return EcoreUtil.copy(CHARACTER_VARYING);
+        }
+
+        /**
+         * Alias for {@link #characterVaryingType()}. Prefer
+         * {@link SqlSimpleTypes#varcharType(int)} for a sized type.
+         */
+        public static SQLSimpleType varcharType() {
+            return characterVaryingType();
+        }
+
+        public static SQLSimpleType characterLargeObjectType() {
+            return EcoreUtil.copy(CHARACTER_LARGE_OBJECT);
+        }
+
+        /** Alias for {@link #characterLargeObjectType()}. */
+        public static SQLSimpleType clobType() {
+            return characterLargeObjectType();
+        }
+
+        public static SQLSimpleType nationalCharacterType() {
+            return EcoreUtil.copy(NATIONAL_CHARACTER);
+        }
+
+        public static SQLSimpleType nationalCharacterVaryingType() {
+            return EcoreUtil.copy(NATIONAL_CHARACTER_VARYING);
+        }
+
+        public static SQLSimpleType nationalCharacterLargeObjectType() {
+            return EcoreUtil.copy(NATIONAL_CHARACTER_LARGE_OBJECT);
+        }
+
+        /** Alias for {@link #nationalCharacterLargeObjectType()}. */
+        public static SQLSimpleType nclobType() {
+            return nationalCharacterLargeObjectType();
+        }
+
+        public static SQLSimpleType numericType() {
+            return EcoreUtil.copy(NUMERIC);
+        }
+
+        public static SQLSimpleType decimalType() {
+            return EcoreUtil.copy(DECIMAL);
+        }
+
+        public static SQLSimpleType integerType() {
+            return EcoreUtil.copy(INTEGER);
+        }
+
+        public static SQLSimpleType smallintType() {
+            return EcoreUtil.copy(SMALLINT);
+        }
+
+        public static SQLSimpleType floatType() {
+            return EcoreUtil.copy(FLOAT);
+        }
+
+        public static SQLSimpleType realType() {
+            return EcoreUtil.copy(REAL);
+        }
+
+        public static SQLSimpleType doublePrecisionType() {
+            return EcoreUtil.copy(DOUBLE_PRECISION);
+        }
+
+        public static SQLSimpleType booleanType() {
+            return EcoreUtil.copy(BOOLEAN);
+        }
+
+        public static SQLSimpleType dateType() {
+            return EcoreUtil.copy(DATE);
+        }
+
+        public static SQLSimpleType timeType() {
+            return EcoreUtil.copy(TIME);
+        }
+
+        public static SQLSimpleType timeWithTimezoneType() {
+            return EcoreUtil.copy(TIME_WITH_TIMEZONE);
+        }
+
+        public static SQLSimpleType timestampType() {
+            return EcoreUtil.copy(TIMESTAMP);
+        }
+
+        public static SQLSimpleType timestampWithTimezoneType() {
+            return EcoreUtil.copy(TIMESTAMP_WITH_TIMEZONE);
+        }
+
+        public static SQLSimpleType intervalType() {
+            return EcoreUtil.copy(INTERVAL);
+        }
+    }
+
+    private static final class Templates {
+
+        private static final RelationalFactory RF = RelationalFactory.eINSTANCE;
+
+        private Templates() {
+        }
+
+        static SQLSimpleType bare(String name, int typeNumber) {
+            SQLSimpleType t = RF.createSQLSimpleType();
+            t.setName(name);
+            t.setTypeNumber(typeNumber);
+            return t;
+        }
+
+        static SQLSimpleType integral(String name, int typeNumber) {
+            // SQL-99: numericScale = 0 for integral types.
+            SQLSimpleType t = bare(name, typeNumber);
+            t.setNumericScale(0);
+            return t;
+        }
+
+        static SQLSimpleType numericRadix(String name, int typeNumber, long radix) {
+            SQLSimpleType t = bare(name, typeNumber);
+            t.setNumericPrecisionRadix(radix);
+            return t;
+        }
+    }
+}

--- a/util/src/main/java/org/eclipse/daanse/cwm/util/resource/relational/Tables.java
+++ b/util/src/main/java/org/eclipse/daanse/cwm/util/resource/relational/Tables.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   SmartCity Jena - initial
+ *   Stefan Bischof (bipolis.org) - initial
+ */
+package org.eclipse.daanse.cwm.util.resource.relational;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import org.eclipse.daanse.cwm.model.cwm.foundation.keysindexes.KeyRelationship;
+import org.eclipse.daanse.cwm.model.cwm.foundation.keysindexes.UniqueKey;
+import org.eclipse.daanse.cwm.model.cwm.objectmodel.core.Feature;
+import org.eclipse.daanse.cwm.model.cwm.objectmodel.core.StructuralFeature;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.Column;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.ForeignKey;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.PrimaryKey;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.Table;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.UniqueConstraint;
+
+public final class Tables {
+
+    private Tables() {
+    }
+
+    /** Primary key found via column back-references, or empty if none. */
+    public static Optional<PrimaryKey> findPrimaryKey(Table table) {
+        if (table == null) {
+            return Optional.empty();
+        }
+        for (Feature f : table.getFeature()) {
+            if (!(f instanceof StructuralFeature sf)) {
+                continue;
+            }
+            for (UniqueKey uk : sf.getUniqueKey()) {
+                if (uk instanceof PrimaryKey pk) {
+                    return Optional.of(pk);
+                }
+            }
+        }
+        return Optional.empty();
+    }
+
+    /** Stream variant of {@link #findUniqueConstraints(Table)}. */
+    public static Stream<UniqueConstraint> uniqueConstraintStream(Table table) {
+        return findUniqueConstraints(table).stream();
+    }
+
+    /** Stream variant of {@link #findForeignKeys(Table)}. */
+    public static Stream<ForeignKey> foreignKeyStream(Table table) {
+        return findForeignKeys(table).stream();
+    }
+
+    /**
+     * All unique constraints (including the primary key) on the table,
+     * deduplicated, declaration order.
+     */
+    public static List<UniqueConstraint> findUniqueConstraints(Table table) {
+        List<UniqueConstraint> out = new ArrayList<>();
+        if (table == null) {
+            return out;
+        }
+        for (Feature f : table.getFeature()) {
+            if (!(f instanceof StructuralFeature sf)) {
+                continue;
+            }
+            for (UniqueKey uk : sf.getUniqueKey()) {
+                if (uk instanceof UniqueConstraint uc && !out.contains(uc)) {
+                    out.add(uc);
+                }
+            }
+        }
+        return out;
+    }
+
+    /**
+     * All foreign keys declared on any column of this table, deduplicated,
+     * declaration order.
+     */
+    public static List<ForeignKey> findForeignKeys(Table table) {
+        List<ForeignKey> out = new ArrayList<>();
+        if (table == null) {
+            return out;
+        }
+        for (Feature f : table.getFeature()) {
+            if (!(f instanceof Column col)) {
+                continue;
+            }
+            for (KeyRelationship kr : col.getKeyRelationship()) {
+                if (kr instanceof ForeignKey fk && !out.contains(fk)) {
+                    out.add(fk);
+                }
+            }
+        }
+        return out;
+    }
+
+    /**
+     * Non-null, has a non-blank name, and declares at least one valid named column.
+     */
+    public static boolean isValid(Table table) {
+        if (table == null || table.getName() == null || table.getName().isBlank()) {
+            return false;
+        }
+        return ColumnSets.columnStream(table).anyMatch(c -> c.getName() != null && !c.getName().isBlank());
+    }
+}

--- a/util/src/main/java/org/eclipse/daanse/cwm/util/resource/relational/UniqueConstraints.java
+++ b/util/src/main/java/org/eclipse/daanse/cwm/util/resource/relational/UniqueConstraints.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   SmartCity Jena - initial
+ *   Stefan Bischof (bipolis.org) - initial
+ */
+package org.eclipse.daanse.cwm.util.resource.relational;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.Column;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.UniqueConstraint;
+import org.eclipse.daanse.cwm.util.objectmodel.core.Classifiers;
+
+public final class UniqueConstraints {
+
+    private UniqueConstraints() {
+    }
+
+    /** Columns covered by the constraint, in declared order. */
+    public static List<Column> columns(UniqueConstraint uc) {
+        return columnStream(uc).toList();
+    }
+
+    /** Stream of columns covered by the constraint. */
+    public static Stream<Column> columnStream(UniqueConstraint uc) {
+        return Classifiers.featureStream(uc == null ? null : uc.getFeature(), Column.class);
+    }
+}

--- a/util/src/main/java/org/eclipse/daanse/cwm/util/resource/relational/Views.java
+++ b/util/src/main/java/org/eclipse/daanse/cwm/util/resource/relational/Views.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   SmartCity Jena - initial
+ *   Stefan Bischof (bipolis.org) - initial
+ */
+package org.eclipse.daanse.cwm.util.resource.relational;
+
+import java.util.Optional;
+
+import org.eclipse.daanse.cwm.model.cwm.foundation.datatypes.QueryExpression;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.View;
+
+public final class Views {
+
+    private Views() {
+    }
+
+    /** The query expression body, or empty if the view has no query. */
+    public static Optional<String> queryBody(View view) {
+        QueryExpression qe = view == null ? null : view.getQueryExpression();
+        return qe == null ? Optional.empty() : Optional.ofNullable(qe.getBody());
+    }
+
+    /** The query expression language, or empty if the view has no query. */
+    public static Optional<String> queryLanguage(View view) {
+        QueryExpression qe = view == null ? null : view.getQueryExpression();
+        return qe == null ? Optional.empty() : Optional.ofNullable(qe.getLanguage());
+    }
+}

--- a/util/src/main/java/org/eclipse/daanse/cwm/util/resource/relational/package-info.java
+++ b/util/src/main/java/org/eclipse/daanse/cwm/util/resource/relational/package-info.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+@org.osgi.annotation.bundle.Export
+@org.osgi.annotation.versioning.Version("0.0.1")
+package org.eclipse.daanse.cwm.util.resource.relational;

--- a/util/src/test/java/org/eclipse/daanse/cwm/util/objectmodel/core/ClassifiersTest.java
+++ b/util/src/test/java/org/eclipse/daanse/cwm/util/objectmodel/core/ClassifiersTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.daanse.cwm.util.objectmodel.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.Column;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.PrimaryKey;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.Table;
+import org.junit.jupiter.api.Test;
+
+class ClassifiersTest {
+
+    private static final RelationalFactory RF = RelationalFactory.eINSTANCE;
+
+    @Test
+    void featureStream_classifierOverload() {
+        Table t = RF.createTable();
+        Column c = RF.createColumn();
+        c.setName("X");
+        t.getFeature().add(c);
+
+        assertThat(Classifiers.featureStream(t, Column.class)).containsExactly(c);
+    }
+
+    @Test
+    void featureStream_listOverload_coversNonClassifierTypes() {
+        // PrimaryKey extends UniqueKey (non-Classifier) but exposes getFeature().
+        PrimaryKey pk = RF.createPrimaryKey();
+        Column id = RF.createColumn();
+        pk.getFeature().add(id);
+
+        assertThat(Classifiers.featureStream(pk.getFeature(), Column.class)).containsExactly(id);
+    }
+
+    @Test
+    void findFeatureByName() {
+        Table t = RF.createTable();
+        Column a = RF.createColumn();
+        a.setName("A");
+        Column b = RF.createColumn();
+        b.setName("B");
+        t.getFeature().add(a);
+        t.getFeature().add(b);
+
+        assertThat(Classifiers.findFeatureByName(t, Column.class, "B")).hasValue(b);
+        assertThat(Classifiers.findFeatureByName(t, Column.class, "MISSING")).isEmpty();
+    }
+
+    @Test
+    void nullSafe() {
+        assertThat(Classifiers.featureStream((Table) null, Column.class)).isEmpty();
+        assertThat(Classifiers.featureStream((java.util.List<Column>) null, Column.class)).isEmpty();
+        assertThat(Classifiers.findFeatureByName(null, Column.class, "X")).isEmpty();
+        assertThat(Classifiers.findFeatureByName(RF.createTable(), null, "X")).isEmpty();
+        assertThat(Classifiers.findFeatureByName(RF.createTable(), Column.class, null)).isEmpty();
+    }
+}

--- a/util/src/test/java/org/eclipse/daanse/cwm/util/objectmodel/core/NamespacesTest.java
+++ b/util/src/test/java/org/eclipse/daanse/cwm/util/objectmodel/core/NamespacesTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.daanse.cwm.util.objectmodel.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.Catalog;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.Schema;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.Table;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.View;
+import org.junit.jupiter.api.Test;
+
+class NamespacesTest {
+
+    private static final RelationalFactory RF = RelationalFactory.eINSTANCE;
+
+    @Test
+    void walkUpTo_returnsFirstAncestorOfType() {
+        Catalog cat = RF.createCatalog();
+        Schema sch = RF.createSchema();
+        cat.getOwnedElement().add(sch);
+        Table t = RF.createTable();
+        sch.getOwnedElement().add(t);
+
+        assertThat(Namespaces.walkUpTo(t.getNamespace(), Schema.class)).containsSame(sch);
+        assertThat(Namespaces.walkUpTo(t.getNamespace(), Catalog.class)).containsSame(cat);
+        assertThat(Namespaces.walkUpTo(null, Schema.class)).isEmpty();
+    }
+
+    @Test
+    void ownedElementStream_filtersByType() {
+        Schema sch = RF.createSchema();
+        Table t = RF.createTable();
+        t.setName("T");
+        View v = RF.createView();
+        sch.getOwnedElement().add(t);
+        sch.getOwnedElement().add(v);
+
+        assertThat(Namespaces.ownedElementStream(sch, Table.class)).containsExactly(t);
+        assertThat(Namespaces.ownedElementStream(sch, View.class)).containsExactly(v);
+        assertThat(Namespaces.ownedElementStream(null, Table.class)).isEmpty();
+    }
+
+    @Test
+    void findOwnedByName_typedFirstMatch() {
+        Catalog cat = RF.createCatalog();
+        Schema sales = RF.createSchema();
+        sales.setName("SALES");
+        Schema hr = RF.createSchema();
+        hr.setName("HR");
+        cat.getOwnedElement().add(sales);
+        cat.getOwnedElement().add(hr);
+
+        assertThat(Namespaces.findOwnedByName(cat, Schema.class, "HR")).containsSame(hr);
+        assertThat(Namespaces.findOwnedByName(cat, Schema.class, "MISSING")).isEmpty();
+        assertThat(Namespaces.findOwnedByName(cat, Table.class, "SALES")).isEmpty();
+    }
+
+    @Test
+    void nullSafe() {
+        assertThat(Namespaces.findOwnedByName(null, Schema.class, "X")).isEmpty();
+        assertThat(Namespaces.findOwnedByName(RF.createCatalog(), null, "X")).isEmpty();
+        assertThat(Namespaces.findOwnedByName(RF.createCatalog(), Schema.class, null)).isEmpty();
+    }
+}

--- a/util/src/test/java/org/eclipse/daanse/cwm/util/resource/relational/CatalogsTest.java
+++ b/util/src/test/java/org/eclipse/daanse/cwm/util/resource/relational/CatalogsTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.daanse.cwm.util.resource.relational;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.Catalog;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.Schema;
+import org.junit.jupiter.api.Test;
+
+class CatalogsTest {
+
+    private static final RelationalFactory RF = RelationalFactory.eINSTANCE;
+
+    @Test
+    void schemas_returnsOnlySchemas() {
+        Catalog cat = RF.createCatalog();
+        Schema a = RF.createSchema();
+        a.setName("A");
+        Schema b = RF.createSchema();
+        b.setName("B");
+        cat.getOwnedElement().add(a);
+        cat.getOwnedElement().add(b);
+        assertThat(Catalogs.schemas(cat)).extracting(Schema::getName).containsExactly("A", "B");
+    }
+
+    @Test
+    void findSchema_byName() {
+        Catalog cat = RF.createCatalog();
+        Schema s = RF.createSchema();
+        s.setName("PUBLIC");
+        cat.getOwnedElement().add(s);
+        assertThat(Catalogs.findSchema(cat, "PUBLIC")).isPresent();
+        assertThat(Catalogs.findSchema(cat, "MISSING")).isEmpty();
+    }
+
+    @Test
+    void nullSafe() {
+        assertThat(Catalogs.schemas(null)).isEmpty();
+        assertThat(Catalogs.findSchema(null, "X")).isEmpty();
+        assertThat(Catalogs.findSchema(RF.createCatalog(), null)).isEmpty();
+    }
+}

--- a/util/src/test/java/org/eclipse/daanse/cwm/util/resource/relational/ColumnSetsTest.java
+++ b/util/src/test/java/org/eclipse/daanse/cwm/util/resource/relational/ColumnSetsTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.daanse.cwm.util.resource.relational;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.Column;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.Table;
+import org.junit.jupiter.api.Test;
+
+class ColumnSetsTest {
+
+    private static final RelationalFactory RF = RelationalFactory.eINSTANCE;
+
+    private static Table tableWith(String... cols) {
+        Table t = RF.createTable();
+        for (String n : cols) {
+            Column c = RF.createColumn();
+            c.setName(n);
+            t.getFeature().add(c);
+        }
+        return t;
+    }
+
+    @Test
+    void columns_andFindColumn() {
+        Table t = tableWith("ID", "NAME", "AGE");
+        assertThat(ColumnSets.columns(t)).extracting(Column::getName).containsExactly("ID", "NAME", "AGE");
+        assertThat(ColumnSets.findColumn(t, "NAME")).isPresent();
+        assertThat(ColumnSets.findColumn(t, "MISSING")).isEmpty();
+    }
+
+    @Test
+    void nullSafe() {
+        assertThat(ColumnSets.columns(null)).isEmpty();
+        assertThat(ColumnSets.columnStream(null)).isEmpty();
+        assertThat(ColumnSets.findColumn(null, "X")).isEmpty();
+        assertThat(ColumnSets.findColumn(RF.createTable(), null)).isEmpty();
+    }
+}

--- a/util/src/test/java/org/eclipse/daanse/cwm/util/resource/relational/ColumnsTest.java
+++ b/util/src/test/java/org/eclipse/daanse/cwm/util/resource/relational/ColumnsTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.daanse.cwm.util.resource.relational;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.Catalog;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.Column;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.Schema;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.Table;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.View;
+import org.junit.jupiter.api.Test;
+
+class ColumnsTest {
+
+    private static final RelationalFactory RF = RelationalFactory.eINSTANCE;
+
+    @Test
+    void ownerVariants() {
+        Table t = RF.createTable();
+        t.setName("T");
+        Column c = RF.createColumn();
+        c.setName("X");
+        t.getFeature().add(c);
+
+        assertThat(Columns.owner(c)).isPresent();
+        assertThat(Columns.namedOwner(c)).hasValueSatisfying(ncs -> assertThat(ncs.getName()).isEqualTo("T"));
+        assertThat(Columns.tableOwner(c)).hasValueSatisfying(tab -> assertThat(tab.getName()).isEqualTo("T"));
+    }
+
+    @Test
+    void tableOwner_empty_whenOwnerIsView() {
+        View v = RF.createView();
+        v.setName("V");
+        Column c = RF.createColumn();
+        c.setName("X");
+        v.getFeature().add(c);
+
+        assertThat(Columns.tableOwner(c)).isEmpty();
+        assertThat(Columns.namedOwner(c)).isPresent();
+    }
+
+    @Test
+    void owner_detached_empty() {
+        Column c = RF.createColumn();
+        c.setName("X");
+        assertThat(Columns.owner(c)).isEmpty();
+        assertThat(Columns.namedOwner(c)).isEmpty();
+        assertThat(Columns.tableOwner(c)).isEmpty();
+    }
+
+    @Test
+    void qualifiedName_fullChain() {
+        Catalog cat = RF.createCatalog();
+        cat.setName("CAT");
+        Schema sch = RF.createSchema();
+        sch.setName("SCH");
+        cat.getOwnedElement().add(sch);
+        Table t = RF.createTable();
+        t.setName("T");
+        sch.getOwnedElement().add(t);
+        Column c = RF.createColumn();
+        c.setName("X");
+        t.getFeature().add(c);
+
+        assertThat(Columns.qualifiedName(c)).isEqualTo("CAT.SCH.T.X");
+    }
+
+    @Test
+    void qualifiedName_detached_onlyColumnName() {
+        Column c = RF.createColumn();
+        c.setName("X");
+        assertThat(Columns.qualifiedName(c)).isEqualTo("X");
+    }
+
+    @Test
+    void isValid() {
+        Column named = RF.createColumn();
+        named.setName("X");
+        assertThat(Columns.isValid(named)).isTrue();
+        assertThat(Columns.isValid(RF.createColumn())).isFalse();
+        assertThat(Columns.isValid(null)).isFalse();
+    }
+}

--- a/util/src/test/java/org/eclipse/daanse/cwm/util/resource/relational/ForeignKeysTest.java
+++ b/util/src/test/java/org/eclipse/daanse/cwm/util/resource/relational/ForeignKeysTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.daanse.cwm.util.resource.relational;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.Column;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.ForeignKey;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.PrimaryKey;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.Table;
+import org.junit.jupiter.api.Test;
+
+class ForeignKeysTest {
+
+    private static final RelationalFactory RF = RelationalFactory.eINSTANCE;
+
+    @Test
+    void columns_filtersToColumnInstances() {
+        ForeignKey fk = RF.createForeignKey();
+        Column a = RF.createColumn();
+        a.setName("A");
+        fk.getFeature().add(a);
+        assertThat(ForeignKeys.columns(fk)).containsExactly(a);
+        assertThat(ForeignKeys.columnStream(fk)).containsExactly(a);
+    }
+
+    @Test
+    void targetTable_resolvesViaUniqueKey() {
+        Table parent = RF.createTable();
+        parent.setName("PARENT");
+        Column pkCol = RF.createColumn();
+        pkCol.setName("ID");
+        parent.getFeature().add(pkCol);
+        PrimaryKey pk = RF.createPrimaryKey();
+        pk.getFeature().add(pkCol);
+
+        ForeignKey fk = RF.createForeignKey();
+        fk.setUniqueKey(pk);
+
+        assertThat(ForeignKeys.targetUniqueKey(fk)).hasValue(pk);
+        assertThat(ForeignKeys.targetTable(fk)).hasValueSatisfying(t -> assertThat(t.getName()).isEqualTo("PARENT"));
+    }
+
+    @Test
+    void nullSafe() {
+        assertThat(ForeignKeys.columns(null)).isEmpty();
+        assertThat(ForeignKeys.columnStream(null)).isEmpty();
+        assertThat(ForeignKeys.targetUniqueKey(null)).isEmpty();
+        assertThat(ForeignKeys.targetTable(null)).isEmpty();
+    }
+}

--- a/util/src/test/java/org/eclipse/daanse/cwm/util/resource/relational/NamedColumnSetsTest.java
+++ b/util/src/test/java/org/eclipse/daanse/cwm/util/resource/relational/NamedColumnSetsTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.daanse.cwm.util.resource.relational;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.Catalog;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.Column;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.Schema;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.Table;
+import org.junit.jupiter.api.Test;
+
+class NamedColumnSetsTest {
+
+    private static final RelationalFactory RF = RelationalFactory.eINSTANCE;
+
+    private static Table table(String name, String... cols) {
+        Table t = RF.createTable();
+        t.setName(name);
+        for (String cn : cols) {
+            Column c = RF.createColumn();
+            c.setName(cn);
+            t.getFeature().add(c);
+        }
+        return t;
+    }
+
+    @Test
+    void findSchemaAndCatalog_viaNamespaceWalk() {
+        Catalog cat = RF.createCatalog();
+        cat.setName("MYCAT");
+        Schema sch = RF.createSchema();
+        sch.setName("PUBLIC");
+        cat.getOwnedElement().add(sch);
+        Table t = table("EMP", "ID");
+        sch.getOwnedElement().add(t);
+
+        assertThat(NamedColumnSets.findSchema(t)).hasValueSatisfying(s -> assertThat(s.getName()).isEqualTo("PUBLIC"));
+        assertThat(NamedColumnSets.findCatalog(t)).hasValueSatisfying(c -> assertThat(c.getName()).isEqualTo("MYCAT"));
+        assertThat(NamedColumnSets.qualifiedName(t)).isEqualTo("MYCAT.PUBLIC.EMP");
+    }
+
+    @Test
+    void qualifiedName_detached_onlyTableName() {
+        Table t = table("ORPHAN");
+        assertThat(NamedColumnSets.findSchema(t)).isEmpty();
+        assertThat(NamedColumnSets.findCatalog(t)).isEmpty();
+        assertThat(NamedColumnSets.qualifiedName(t)).isEqualTo("ORPHAN");
+    }
+
+    @Test
+    void nullSafe() {
+        assertThat(NamedColumnSets.qualifiedName(null)).isNull();
+    }
+}

--- a/util/src/test/java/org/eclipse/daanse/cwm/util/resource/relational/RowsTest.java
+++ b/util/src/test/java/org/eclipse/daanse/cwm/util/resource/relational/RowsTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.daanse.cwm.util.resource.relational;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.eclipse.daanse.cwm.model.cwm.objectmodel.instance.DataSlot;
+import org.eclipse.daanse.cwm.model.cwm.objectmodel.instance.InstanceFactory;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.Column;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.Row;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.RowSet;
+import org.junit.jupiter.api.Test;
+
+class RowsTest {
+
+    private static final RelationalFactory RF = RelationalFactory.eINSTANCE;
+    private static final InstanceFactory IF = InstanceFactory.eINSTANCE;
+
+    @Test
+    void rowSet_rows_filtersOnlyRows() {
+        RowSet rs = RF.createRowSet();
+        Row r = RF.createRow();
+        rs.getOwnedElement().add(r);
+        assertThat(RowSets.rows(rs)).containsExactly(r);
+        assertThat(RowSets.rowStream(rs)).containsExactly(r);
+    }
+
+    @Test
+    void slots_dataValue_andValueOf() {
+        Column col = RF.createColumn();
+        col.setName("A");
+        DataSlot ds = IF.createDataSlot();
+        ds.setFeature(col);
+        ds.setDataValue("hello");
+
+        Row row = RF.createRow();
+        row.getSlot().add(ds);
+
+        assertThat(Rows.slots(row)).containsExactly(ds);
+        assertThat(Rows.slotStream(row)).containsExactly(ds);
+        assertThat(Rows.valueOf(row, col)).hasValue("hello");
+
+        Column other = RF.createColumn();
+        other.setName("B");
+        assertThat(Rows.valueOf(row, other)).isEmpty();
+    }
+
+    @Test
+    void nullSafe() {
+        assertThat(RowSets.rows(null)).isEmpty();
+        assertThat(RowSets.rowStream(null)).isEmpty();
+        assertThat(Rows.slots(null)).isEmpty();
+        assertThat(Rows.valueOf(null, RF.createColumn())).isEmpty();
+        assertThat(Rows.valueOf(RF.createRow(), null)).isEmpty();
+    }
+}

--- a/util/src/test/java/org/eclipse/daanse/cwm/util/resource/relational/SchemasTest.java
+++ b/util/src/test/java/org/eclipse/daanse/cwm/util/resource/relational/SchemasTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.daanse.cwm.util.resource.relational;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.Catalog;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.Schema;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.Table;
+import org.junit.jupiter.api.Test;
+
+class SchemasTest {
+
+    private static final RelationalFactory RF = RelationalFactory.eINSTANCE;
+
+    @Test
+    void tablesAndViews_areTypeFiltered() {
+        Schema sch = RF.createSchema();
+        sch.setName("PUBLIC");
+        Table t = RF.createTable();
+        t.setName("EMP");
+        sch.getOwnedElement().add(t);
+        sch.getOwnedElement().add(RF.createView());
+
+        assertThat(Schemas.tables(sch)).singleElement().extracting(Table::getName).isEqualTo("EMP");
+        assertThat(Schemas.views(sch)).hasSize(1);
+        assertThat(Schemas.columnSets(sch)).hasSize(2);
+    }
+
+    @Test
+    void findCatalog_viaNamespaceWalk() {
+        Catalog cat = RF.createCatalog();
+        cat.setName("MYCAT");
+        Schema sch = RF.createSchema();
+        sch.setName("PUBLIC");
+        cat.getOwnedElement().add(sch);
+
+        assertThat(Schemas.findCatalog(sch)).hasValueSatisfying(c -> assertThat(c.getName()).isEqualTo("MYCAT"));
+    }
+
+    @Test
+    void findCatalog_detached_empty() {
+        Schema sch = RF.createSchema();
+        assertThat(Schemas.findCatalog(sch)).isEmpty();
+    }
+
+    @Test
+    void findTableAndView_byName() {
+        Schema sch = RF.createSchema();
+        Table t = RF.createTable();
+        t.setName("EMP");
+        sch.getOwnedElement().add(t);
+
+        assertThat(Schemas.findTable(sch, "EMP")).isPresent();
+        assertThat(Schemas.findTable(sch, "MISSING")).isEmpty();
+        assertThat(Schemas.findView(sch, "EMP")).isEmpty();
+    }
+
+    @Test
+    void nullSafe() {
+        assertThat(Schemas.tables(null)).isEmpty();
+        assertThat(Schemas.findCatalog(null)).isEmpty();
+        assertThat(Schemas.findTable(null, "X")).isEmpty();
+        assertThat(Schemas.findTable(RF.createSchema(), null)).isEmpty();
+    }
+
+    @Test
+    void qualifiedName_includesCatalog() {
+        Catalog cat = RF.createCatalog();
+        cat.setName("CAT");
+        Schema sch = RF.createSchema();
+        sch.setName("SCH");
+        cat.getOwnedElement().add(sch);
+        assertThat(Schemas.qualifiedName(sch)).isEqualTo("CAT.SCH");
+    }
+
+    @Test
+    void qualifiedName_detachedReturnsBareName() {
+        Schema sch = RF.createSchema();
+        sch.setName("ORPHAN");
+        assertThat(Schemas.qualifiedName(sch)).isEqualTo("ORPHAN");
+    }
+
+}

--- a/util/src/test/java/org/eclipse/daanse/cwm/util/resource/relational/SqlSimpleTypesTest.java
+++ b/util/src/test/java/org/eclipse/daanse/cwm/util/resource/relational/SqlSimpleTypesTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.daanse.cwm.util.resource.relational;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.Types;
+
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.SQLSimpleType;
+import org.junit.jupiter.api.Test;
+
+class SqlSimpleTypesTest {
+
+    @Test
+    void sql99Defaults_haveNameAndTypeNumber() {
+        SQLSimpleType t = SqlSimpleTypes.Sql99.integerType();
+        assertThat(t.getName()).isEqualTo("INTEGER");
+        assertThat(t.getTypeNumber()).isEqualTo(Types.INTEGER);
+        assertThat(t.getNumericScale()).isEqualTo(0);
+    }
+
+    @Test
+    void sql99_allCategories() {
+        assertThat(SqlSimpleTypes.Sql99.bitType().getTypeNumber()).isEqualTo(Types.BIT);
+        assertThat(SqlSimpleTypes.Sql99.characterVaryingType().getTypeNumber()).isEqualTo(Types.VARCHAR);
+        assertThat(SqlSimpleTypes.Sql99.numericType().getNumericPrecisionRadix()).isEqualTo(10);
+        assertThat(SqlSimpleTypes.Sql99.floatType().getNumericPrecisionRadix()).isEqualTo(2);
+        assertThat(SqlSimpleTypes.Sql99.smallintType().getNumericScale()).isEqualTo(0);
+        assertThat(SqlSimpleTypes.Sql99.dateType().getTypeNumber()).isEqualTo(Types.DATE);
+        assertThat(SqlSimpleTypes.Sql99.booleanType().getTypeNumber()).isEqualTo(Types.BOOLEAN);
+    }
+
+    @Test
+    void varchar_parametrized_setsLength() {
+        SQLSimpleType t = SqlSimpleTypes.varcharType(128);
+        assertThat(t.getName()).isEqualTo("CHARACTER VARYING");
+        assertThat(t.getTypeNumber()).isEqualTo(Types.VARCHAR);
+        assertThat(t.getCharacterMaximumLength()).isEqualTo(128);
+    }
+
+    @Test
+    void decimal_parametrized_setsPrecisionAndScale() {
+        SQLSimpleType t = SqlSimpleTypes.decimalType(10, 2);
+        assertThat(t.getName()).isEqualTo("DECIMAL");
+        assertThat(t.getTypeNumber()).isEqualTo(Types.DECIMAL);
+        assertThat(t.getNumericPrecision()).isEqualTo(10);
+        assertThat(t.getNumericScale()).isEqualTo(2);
+        assertThat(t.getNumericPrecisionRadix()).isEqualTo(10);
+    }
+
+    @Test
+    void factories_returnFreshInstances() {
+        SQLSimpleType a = SqlSimpleTypes.varcharType(10);
+        SQLSimpleType b = SqlSimpleTypes.varcharType(20);
+        assertThat(a).isNotSameAs(b);
+        assertThat(a.getCharacterMaximumLength()).isEqualTo(10);
+        assertThat(b.getCharacterMaximumLength()).isEqualTo(20);
+    }
+
+    @Test
+    void byName_canonicalAndAliases() {
+        assertThat(SqlSimpleTypes.byName("INTEGER")).isPresent();
+        assertThat(SqlSimpleTypes.byName("integer")).isPresent();
+        assertThat(SqlSimpleTypes.byName("VARCHAR"))
+                .hasValueSatisfying(t -> assertThat(t.getTypeNumber()).isEqualTo(Types.VARCHAR));
+        assertThat(SqlSimpleTypes.byName("CHARACTER  VARYING")).isPresent();
+        assertThat(SqlSimpleTypes.byName("INT")).isPresent();
+        assertThat(SqlSimpleTypes.byName("BIGINT"))
+                .hasValueSatisfying(t -> assertThat(t.getTypeNumber()).isEqualTo(Types.BIGINT));
+        assertThat(SqlSimpleTypes.byName("FROBNICATE")).isEmpty();
+        assertThat(SqlSimpleTypes.byName(null)).isEmpty();
+    }
+
+    @Test
+    void inspectionClassification() {
+        assertThat(SqlSimpleTypes.isNumeric(SqlSimpleTypes.Sql99.integerType())).isTrue();
+        assertThat(SqlSimpleTypes.isNumeric(SqlSimpleTypes.decimalType(10, 2))).isTrue();
+        assertThat(SqlSimpleTypes.isNumeric(SqlSimpleTypes.varcharType(10))).isFalse();
+
+        assertThat(SqlSimpleTypes.isText(SqlSimpleTypes.varcharType(255))).isTrue();
+        assertThat(SqlSimpleTypes.isText(SqlSimpleTypes.characterType(10))).isTrue();
+        assertThat(SqlSimpleTypes.isText(SqlSimpleTypes.Sql99.integerType())).isFalse();
+
+        assertThat(SqlSimpleTypes.isTemporal(SqlSimpleTypes.Sql99.dateType())).isTrue();
+        assertThat(SqlSimpleTypes.isTemporal(SqlSimpleTypes.Sql99.timestampType())).isTrue();
+        assertThat(SqlSimpleTypes.isTemporal(SqlSimpleTypes.Sql99.integerType())).isFalse();
+    }
+
+    @Test
+    void describe_formats() {
+        assertThat(SqlSimpleTypes.describe(SqlSimpleTypes.varcharType(255))).isEqualTo("CHARACTER VARYING(255)");
+        assertThat(SqlSimpleTypes.describe(SqlSimpleTypes.decimalType(10, 2))).isEqualTo("DECIMAL(10,2)");
+        assertThat(SqlSimpleTypes.describe(SqlSimpleTypes.Sql99.integerType())).isEqualTo("INTEGER");
+        assertThat(SqlSimpleTypes.describe(null)).isNull();
+    }
+}

--- a/util/src/test/java/org/eclipse/daanse/cwm/util/resource/relational/TablesTest.java
+++ b/util/src/test/java/org/eclipse/daanse/cwm/util/resource/relational/TablesTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.daanse.cwm.util.resource.relational;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.Column;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.ForeignKey;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.PrimaryKey;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.Table;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.UniqueConstraint;
+import org.junit.jupiter.api.Test;
+
+class TablesTest {
+
+    private static final RelationalFactory RF = RelationalFactory.eINSTANCE;
+
+    private static Table table(String name, String... cols) {
+        Table t = RF.createTable();
+        t.setName(name);
+        for (String cn : cols) {
+            Column c = RF.createColumn();
+            c.setName(cn);
+            t.getFeature().add(c);
+        }
+        return t;
+    }
+
+    @Test
+    void findPrimaryKey_viaColumnBackReference() {
+        Table t = table("EMP", "ID", "NAME");
+        Column idCol = (Column) t.getFeature().get(0);
+
+        PrimaryKey pk = RF.createPrimaryKey();
+        pk.setName("PK_EMP");
+        pk.getFeature().add(idCol);
+
+        assertThat(Tables.findPrimaryKey(t)).hasValueSatisfying(p -> assertThat(p.getName()).isEqualTo("PK_EMP"));
+    }
+
+    @Test
+    void findPrimaryKey_noPk_empty() {
+        Table t = table("EMP", "ID", "NAME");
+        assertThat(Tables.findPrimaryKey(t)).isEmpty();
+    }
+
+    @Test
+    void findUniqueConstraints_dedups() {
+        Table t = table("EMP", "A", "B");
+        UniqueConstraint uc = RF.createUniqueConstraint();
+        uc.setName("UC");
+        uc.getFeature().add((Column) t.getFeature().get(0));
+        uc.getFeature().add((Column) t.getFeature().get(1));
+
+        assertThat(Tables.findUniqueConstraints(t)).containsExactly(uc);
+    }
+
+    @Test
+    void findForeignKeys_viaColumnBackReference() {
+        Table t = table("ORDER_ITEMS", "ORDER_ID", "PRODUCT_ID");
+        Column orderCol = (Column) t.getFeature().get(0);
+
+        ForeignKey fk = RF.createForeignKey();
+        fk.setName("FK_ORDER");
+        fk.getFeature().add(orderCol);
+
+        assertThat(Tables.findForeignKeys(t)).singleElement()
+                .satisfies(f -> assertThat(f.getName()).isEqualTo("FK_ORDER"));
+    }
+
+    @Test
+    void isValid() {
+        assertThat(Tables.isValid(table("T", "C"))).isTrue();
+        assertThat(Tables.isValid(table("", "C"))).isFalse();
+        assertThat(Tables.isValid(table("T"))).isFalse();
+        assertThat(Tables.isValid(null)).isFalse();
+    }
+
+    @Test
+    void streamVariants_forUniqueAndForeignKeys() {
+        Table t = table("EMP", "ID", "DEPT_ID");
+        Column id = (Column) t.getFeature().get(0);
+        Column dept = (Column) t.getFeature().get(1);
+
+        PrimaryKey pk = RF.createPrimaryKey();
+        pk.getFeature().add(id);
+
+        ForeignKey fk = RF.createForeignKey();
+        fk.getFeature().add(dept);
+
+        // PrimaryKey is also a UniqueConstraint subtype — it's counted once.
+        assertThat(Tables.uniqueConstraintStream(t).count()).isEqualTo(1);
+        assertThat(Tables.foreignKeyStream(t).count()).isEqualTo(1);
+    }
+}


### PR DESCRIPTION
New cwm.util module providing typed helpers

- Classifiers/Namespaces
- ColumnSets/Tables/NamedColumnSets/Schemas/Catalogs/Views —domain navigation (columns, schemas, qualified names).

- PrimaryKeys/UniqueConstraints/ForeignKeys - key column access and target-table resolution.
- Rows/RowSets/DataSlots — InlineTable row + slot navigation.

- SqlSimpleTypes — SQL-99 type factories (Sql99 nested) plus byName lookup and isNumeric/isText/isTemporal/describe inspection.

### What does this PR do?

### Screenshot / video of UI
