### PR TITLE
feat(testkit): build and load a dataset from its CWM description

### DIFF
--- a/data/api/src/main/java/org/eclipse/daanse/cwm/data/api/RawRecord.java
+++ b/data/api/src/main/java/org/eclipse/daanse/cwm/data/api/RawRecord.java
@@ -13,21 +13,48 @@
  */
 package org.eclipse.daanse.cwm.data.api;
 
+import java.util.List;
 import java.util.Map;
 
 /**
- * Represents a single parsed row from a data source as field name to raw string
- * value pairs. This is the common data type flowing through CSV pipelines.
+ * A single parsed row, as raw string values in the order the source produced
+ * them, with the field names alongside.
+ *
+ * <p>
+ * The names belong to the source, not to the row, so {@link #fieldNames()}
+ * returns the same list for every record: a consumer resolves the positions it
+ * needs once and reads {@link #field(int)} afterwards, rather than looking up a
+ * name per field per row.
  */
 public interface RawRecord {
 
     /**
-     * @return the field values keyed by field name
+     * The field names, in value order. The same instance for every record of one
+     * source, so it is safe (and intended) to resolve positions from it once.
      */
-    Map<String, String> fields();
+    List<String> fieldNames();
+
+    /** How many values this record has. */
+    int fieldCount();
 
     /**
-     * @return the line number in the source (1-based)
+     * The value at {@code index}, or {@code null} if the row is shorter than the
+     * header.
      */
+    String field(int index);
+
+    /**
+     * The value of the named field, or {@code null} if there is no such field.
+     * Convenience for occasional access; see {@link #fieldNames()}.
+     */
+    String field(String name);
+
+    /**
+     * The values keyed by field name. Materialised on demand: nothing builds this
+     * unless it is asked for.
+     */
+    Map<String, String> asMap();
+
+    /** The line number in the source (1-based). */
     long lineNumber();
 }

--- a/data/sink.jdbc/src/main/java/org/eclipse/daanse/cwm/data/sink/jdbc/DatabaseRecordSink.java
+++ b/data/sink.jdbc/src/main/java/org/eclipse/daanse/cwm/data/sink/jdbc/DatabaseRecordSink.java
@@ -53,7 +53,50 @@ public class DatabaseRecordSink implements RecordSink<RawRecord> {
     private Flow.Subscription subscription;
     private Connection connection;
     private PreparedStatement preparedStatement;
-    private int batchCount;
+    private long batchCount;
+
+    /** Whether this database has transactions at all; ClickHouse has none. */
+    private boolean transactional;
+
+    // Resolved once in onSubscribe: everything the per-row loop needs, in arrays
+    // indexed by column, so nothing is looked up or unwrapped per value.
+    private String[] sourceFieldNames;
+    private JDBCType[] columnTypes;
+    private java.util.function.Function<String, Object>[] converters;
+
+    /**
+     * Columns the model calls boolean but this database stores as a number.
+     * Resolved once, from the dialect, because it holds for the whole table.
+     */
+    private boolean[] booleanAsNumber;
+
+    /**
+     * Position of each of our columns in the incoming records, resolved from the
+     * first one. Null until then.
+     */
+    private int[] sourceIndexes;
+
+    /**
+     * Rows per INSERT statement. A load costs what its <em>statements</em> cost:
+     * a driver may implement {@code executeBatch()} as a loop over
+     * {@code execute()} — DuckDB's does — so writing N tuples per statement
+     * divides the bind and plan cycles by N.
+     */
+    private static final int ROWS_PER_INSERT = 200;
+
+    /**
+     * Bound-parameter ceiling per statement. PostgreSQL refuses more than 65535
+     * and SQL Server more than 2100; staying below both costs nothing, because the
+     * gain flattens out long before either.
+     */
+    private static final int MAX_PARAMETERS = 2_000;
+
+    /** How many tuples the block statement carries; 1 means there is none. */
+    private int tuplesPerStatement;
+    /** Rows already bound into the block statement, 0..tuplesPerStatement-1. */
+    private int boundRows;
+    /** Carries {@link #tuplesPerStatement} tuples; null when that is 1. */
+    private PreparedStatement blockStatement;
 
     public DatabaseRecordSink(DataSource dataSource, Dialect dialect, TableReference targetTable,
             List<FieldMapping> fieldMappings, List<JDBCType> jdbcTypes, int batchSize) {
@@ -65,12 +108,28 @@ public class DatabaseRecordSink implements RecordSink<RawRecord> {
         this.batchSize = batchSize;
     }
 
+    /**
+     * How many rows this sink bound and sent, valid once {@link #onComplete()}
+     * has returned. It is what the sink believes it wrote — comparing it with
+     * {@code SELECT count(*)} is what catches a table that accepted every
+     * statement and stored nothing.
+     */
+    public long rowCount() {
+        return batchCount;
+    }
+
     @Override
     public void onSubscribe(Flow.Subscription subscription) {
         this.subscription = subscription;
         try {
             connection = dataSource.getConnection();
-            connection.setAutoCommit(false);
+            // ClickHouse has no transactions and answers setAutoCommit(false)
+            // with a SQLFeatureNotSupportedException. Every statement stands on
+            // its own there; there is nothing to open and nothing to commit.
+            transactional = dialect.supportsTransactions();
+            if (transactional) {
+                connection.setAutoCommit(false);
+            }
 
             List<ColumnDefinition> columns = fieldMappings.stream().map(m -> {
                 ColumnReference ref = new ColumnReference(java.util.Optional.empty(), m.targetFeatureName());
@@ -81,10 +140,19 @@ public class DatabaseRecordSink implements RecordSink<RawRecord> {
                         ColumnMetaData.GeneratedColumn.UNKNOWN);
                 return (ColumnDefinition) new ColumnDefinitionRecord(ref, meta);
             }).toList();
-            String sql = dialect.ddlGenerator().insertInto(targetTable, columns);
+            // The single-row statement always exists: it takes the tail of the file,
+            // the rows that do not fill a whole block.
+            preparedStatement = connection.prepareStatement(dialect.ddlGenerator().insertInto(targetTable, columns));
 
-            preparedStatement = connection.prepareStatement(sql);
+            tuplesPerStatement = Math.min(tuplesPerStatement(columns.size()),
+                    dialect.ddlGenerator().maxInsertRows());
+            if (tuplesPerStatement > 1) {
+                blockStatement = connection
+                        .prepareStatement(dialect.ddlGenerator().insertInto(targetTable, columns, tuplesPerStatement));
+            }
             batchCount = 0;
+            boundRows = 0;
+            resolveColumns();
 
             subscription.request(Long.MAX_VALUE);
         } catch (SQLException e) {
@@ -92,31 +160,69 @@ public class DatabaseRecordSink implements RecordSink<RawRecord> {
         }
     }
 
+    @SuppressWarnings("unchecked")
+    private void resolveColumns() {
+        int count = fieldMappings.size();
+        sourceFieldNames = new String[count];
+        columnTypes = new JDBCType[count];
+        converters = new java.util.function.Function[count];
+        booleanAsNumber = new boolean[count];
+        // The model states BOOLEAN because that is the logical type; what the
+        // column actually is was decided by the dialect when the table was
+        // created, and most of them chose a number.
+        boolean numericBooleans = !"BOOLEAN".equalsIgnoreCase(dialect.ddlGenerator().booleanTypeName());
+        for (int i = 0; i < count; i++) {
+            FieldMapping mapping = fieldMappings.get(i);
+            sourceFieldNames[i] = mapping.sourceFieldName();
+            columnTypes[i] = i < jdbcTypes.size() ? jdbcTypes.get(i) : JDBCType.VARCHAR;
+            converters[i] = mapping.converter().orElse(null);
+            booleanAsNumber[i] = numericBooleans
+                    && (columnTypes[i] == JDBCType.BOOLEAN || columnTypes[i] == JDBCType.BIT);
+        }
+    }
+
+    /**
+     * How many tuples one statement carries, capped so the parameter count stays
+     * within what every driver accepts.
+     */
+    private static int tuplesPerStatement(int columnCount) {
+        if (ROWS_PER_INSERT <= 1 || columnCount <= 0) {
+            return 1;
+        }
+        return Math.max(1, Math.min(ROWS_PER_INSERT, MAX_PARAMETERS / columnCount));
+    }
+
+    /**
+     * Looks up each source field name once, against the record's own field-name
+     * list. A name the source does not carry gets -1, which reads back as null —
+     * the same result the map lookup gave.
+     */
+    private void resolveSourceIndexes(RawRecord item) {
+        java.util.List<String> names = item.fieldNames();
+        int[] indexes = new int[sourceFieldNames.length];
+        for (int i = 0; i < sourceFieldNames.length; i++) {
+            indexes[i] = names.indexOf(sourceFieldNames[i]);
+        }
+        sourceIndexes = indexes;
+    }
+
     @Override
     public void onNext(RawRecord item) {
         try {
-            int colIndex = 1;
-            for (int i = 0; i < fieldMappings.size(); i++) {
-                FieldMapping mapping = fieldMappings.get(i);
-                String rawValue = item.fields().get(mapping.sourceFieldName());
-                JDBCType jdbcType = i < jdbcTypes.size() ? jdbcTypes.get(i) : JDBCType.VARCHAR;
-
-                if (mapping.converter().isPresent()) {
-                    Object converted = rawValue == null ? null : mapping.converter().get().apply(rawValue);
-                    if (converted == null) {
-                        preparedStatement.setNull(colIndex++, jdbcType.getVendorTypeNumber());
-                    } else {
-                        preparedStatement.setObject(colIndex++, converted, jdbcType.getVendorTypeNumber());
-                    }
-                } else {
-                    TypeConverter.setTypedValue(preparedStatement, colIndex++, jdbcType, rawValue);
+            if (tuplesPerStatement > 1) {
+                // Held rather than bound straight away: a statement with N tuples can
+                // only be executed with all N bound, and the file's last block is
+                // shorter than that. What is held is at most N records.
+                block.add(item);
+                if (block.size() == tuplesPerStatement) {
+                    flushBlock();
                 }
+                return;
             }
 
+            bindRow(preparedStatement, 0, item);
             preparedStatement.addBatch();
-            preparedStatement.clearParameters();
             batchCount++;
-
             if (batchCount % batchSize == 0) {
                 executeBatch();
             }
@@ -127,11 +233,55 @@ public class DatabaseRecordSink implements RecordSink<RawRecord> {
         }
     }
 
+    /** Binds and queues a full block. */
+    private void flushBlock() throws SQLException {
+        for (int row = 0; row < block.size(); row++) {
+            bindRow(blockStatement, row * sourceFieldNames.length, block.get(row));
+        }
+        // No clearParameters: addBatch has taken the values, and every parameter is
+        // bound again on the next block.
+        blockStatement.addBatch();
+        batchCount += block.size();
+        block.clear();
+        if (batchCount % batchSize < tuplesPerStatement) {
+            blockStatement.executeBatch();
+        }
+    }
+
+    /** The rows waiting for their block to fill. */
+    private final List<RawRecord> block = new java.util.ArrayList<>();
+
+    /** Binds one record into the parameters starting at {@code base}. */
+    private void bindRow(PreparedStatement statement, int base, RawRecord item) throws SQLException {
+        // Where each of our columns sits in the record. The record's field names
+        // are the source's, one list for the whole file, so this holds from the
+        // first row to the last and is resolved once.
+        if (sourceIndexes == null) {
+            resolveSourceIndexes(item);
+        }
+        for (int i = 0; i < sourceFieldNames.length; i++) {
+            String rawValue = item.field(sourceIndexes[i]);
+            int index = base + i + 1;
+            if (booleanAsNumber[i] && converters[i] == null) {
+                TypeConverter.setBooleanAsNumber(statement, index, rawValue);
+            } else if (converters[i] == null) {
+                TypeConverter.setTypedValue(statement, index, columnTypes[i], rawValue);
+            } else {
+                Object converted = rawValue == null ? null : converters[i].apply(rawValue);
+                if (converted == null) {
+                    statement.setNull(index, columnTypes[i].getVendorTypeNumber());
+                } else {
+                    statement.setObject(index, converted, columnTypes[i].getVendorTypeNumber());
+                }
+            }
+        }
+    }
+
     @Override
     public void onError(Throwable throwable) {
         LOGGER.error("Error in database ETL pipeline", throwable);
         try {
-            if (connection != null) {
+            if (connection != null && transactional) {
                 connection.rollback();
             }
         } catch (SQLException e) {
@@ -143,11 +293,24 @@ public class DatabaseRecordSink implements RecordSink<RawRecord> {
     @Override
     public void onComplete() {
         try {
-            if (batchCount % batchSize != 0) {
+            if (blockStatement != null) {
+                blockStatement.executeBatch();
+                // The tail — fewer rows than the block statement has tuples — goes in
+                // one at a time through the single-row statement.
+                for (RawRecord record : block) {
+                    bindRow(preparedStatement, 0, record);
+                    preparedStatement.addBatch();
+                }
+                batchCount += block.size();
+                block.clear();
+                preparedStatement.executeBatch();
+            } else if (batchCount % batchSize != 0) {
                 executeBatch();
             }
-            connection.commit();
-            connection.setAutoCommit(true);
+            if (transactional) {
+                connection.commit();
+                connection.setAutoCommit(true);
+            }
             LOGGER.debug("Database import completed for table {}", targetTable.name());
         } catch (SQLException e) {
             throw new JdbcSinkException("Error completing database import", e);
@@ -156,14 +319,24 @@ public class DatabaseRecordSink implements RecordSink<RawRecord> {
         }
     }
 
+    /**
+     * Sends the accumulated rows. It does <em>not</em> commit: one table is one
+     * transaction, committed in {@link #onComplete()}. Committing per batch made
+     * the {@code setAutoCommit(false)} above pointless and turned a load into as
+     * many durable transactions as it had batches.
+     */
     private void executeBatch() throws SQLException {
-        long start = System.currentTimeMillis();
         preparedStatement.executeBatch();
-        connection.commit();
-        LOGGER.debug("Batch executed in {}ms", System.currentTimeMillis() - start);
     }
 
     private void closeResources() {
+        try {
+            if (blockStatement != null) {
+                blockStatement.close();
+            }
+        } catch (SQLException e) {
+            LOGGER.warn("Error closing the multi-row PreparedStatement", e);
+        }
         try {
             if (preparedStatement != null) {
                 preparedStatement.close();

--- a/data/sink.jdbc/src/main/java/org/eclipse/daanse/cwm/data/sink/jdbc/TypeConverter.java
+++ b/data/sink.jdbc/src/main/java/org/eclipse/daanse/cwm/data/sink/jdbc/TypeConverter.java
@@ -41,32 +41,35 @@ public class TypeConverter {
     public static void setTypedValue(PreparedStatement ps, int index, JDBCType jdbcType, String value)
             throws SQLException {
         if (value == null || "NULL".equalsIgnoreCase(value)) {
-            ps.setObject(index, null);
+            // With a type code: an untyped null binds as "unspecified" on pgjdbc,
+            // which the server cannot resolve when a column is null in every tuple.
+            ps.setNull(index, jdbcType.getVendorTypeNumber());
             return;
         }
-
+            // parseX, not valueOf: valueOf boxes and unboxes again for the
+            // primitive setter, allocating once per value.
         switch (jdbcType) {
         case BOOLEAN:
-            ps.setBoolean(index, value.isEmpty() ? Boolean.FALSE : Boolean.valueOf(value));
+            ps.setBoolean(index, parseBoolean(value));
             break;
         case BIGINT:
-            ps.setLong(index, value.isEmpty() ? 0L : Long.valueOf(value));
+            ps.setLong(index, value.isEmpty() ? 0L : Long.parseLong(value));
             break;
         case DATE:
             ps.setDate(index, Date.valueOf(value));
             break;
         case INTEGER:
-            ps.setInt(index, value.isEmpty() ? 0 : Integer.valueOf(value));
+            ps.setInt(index, value.isEmpty() ? 0 : Integer.parseInt(value));
             break;
         case DECIMAL:
         case NUMERIC:
         case REAL:
         case DOUBLE:
         case FLOAT:
-            ps.setDouble(index, value.isEmpty() ? 0.0 : Double.valueOf(value));
+            ps.setDouble(index, value.isEmpty() ? 0.0 : Double.parseDouble(value));
             break;
         case SMALLINT:
-            ps.setShort(index, value.isEmpty() ? (short) 0 : Short.valueOf(value));
+            ps.setShort(index, value.isEmpty() ? (short) 0 : Short.parseShort(value));
             break;
         case TIMESTAMP:
             ps.setTimestamp(index, Timestamp.valueOf(value));
@@ -85,5 +88,33 @@ public class TypeConverter {
             ps.setString(index, value);
             break;
         }
+    }
+
+    /**
+     * Binds a boolean into a numeric column, as 1 or 0.
+     *
+     * <p>
+     * Most databases here store booleans as a number — see
+     * {@code DdlGenerator.booleanTypeName()} — and several refuse
+     * {@code setBoolean} against that column. The text is still read as a
+     * boolean, so both {@code 1/0} and {@code true/false} arrive correctly.
+     */
+    public static void setBooleanAsNumber(PreparedStatement ps, int index, String value) throws SQLException {
+        if (value == null || "NULL".equalsIgnoreCase(value)) {
+            ps.setNull(index, JDBCType.SMALLINT.getVendorTypeNumber());
+            return;
+        }
+        // An empty field is false, not null - the same reading the native path
+        // gives it, and the same the other types give an empty numeric field.
+        ps.setShort(index, parseBoolean(value) ? (short) 1 : (short) 0);
+    }
+
+    /**
+     * A boolean as a CSV writes it. {@code Boolean.valueOf("1")} is {@code false},
+     * so a source that encodes booleans as 1/0 - which the shipped datasets do -
+     * would load every one of them as false without this.
+     */
+    private static boolean parseBoolean(String value) {
+        return "1".equals(value) || "true".equalsIgnoreCase(value);
     }
 }

--- a/data/source.csv/src/main/java/org/eclipse/daanse/cwm/data/source/csv/CsvRecordPublisher.java
+++ b/data/source.csv/src/main/java/org/eclipse/daanse/cwm/data/source/csv/CsvRecordPublisher.java
@@ -205,12 +205,31 @@ public class CsvRecordPublisher implements RecordSource<RawRecord> {
                 lineCounter++;
                 demand.decrementAndGet();
 
-                Map<String, String> fields = new LinkedHashMap<>();
-                for (int i = 0; i < fieldNames.size() && i < csvRecord.getFieldCount(); i++) {
-                    fields.put(fieldNames.get(i), csvRecord.getField(i));
+                // A row whose width differs from the header is a broken file, not
+                // a short row. Taking min() of the two and leaving the rest null
+                // turns a shifted separator into a table that loads cleanly and
+                // holds the wrong data - which is the failure mode that hides
+                // itself. Every field the header names must be present.
+                int width = fieldNames.size();
+                if (csvRecord.getFieldCount() != width) {
+                    if (!cancelled.getAndSet(true)) {
+                        closeResources();
+                        subscriber.onError(new IllegalStateException(csvFilePath + ", line " + lineCounter
+                                + ": expected " + width + " fields but the row has " + csvRecord.getFieldCount()));
+                    }
+                    return;
                 }
 
-                RawRecord rawRecord = new RawRecordR(Map.copyOf(fields), lineCounter);
+                // The names were fixed when the header was read; only the values
+                // change from row to row. Building a map here and looking the same
+                // keys up again downstream cost two maps and 2N hash operations a
+                // row, for a mapping that never varies.
+                String[] values = new String[width];
+                for (int i = 0; i < width; i++) {
+                    values[i] = csvRecord.getField(i);
+                }
+
+                RawRecord rawRecord = new RawRecordR(fieldNames, values, lineCounter);
 
                 try {
                     subscriber.onNext(rawRecord);

--- a/data/source.csv/src/main/java/org/eclipse/daanse/cwm/data/source/csv/record/RawRecordR.java
+++ b/data/source.csv/src/main/java/org/eclipse/daanse/cwm/data/source/csv/record/RawRecordR.java
@@ -13,12 +13,48 @@
  */
 package org.eclipse.daanse.cwm.data.source.csv.record;
 
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.eclipse.daanse.cwm.data.api.RawRecord;
 
 /**
- * Record implementation of {@link RawRecord}.
+ * A row as an array of values plus the field names of its source.
+ *
+ * <p>
+ * {@code fieldNames} is meant to be the one list the source built for itself,
+ * handed to every record unchanged: it is not copied here, and it must not be
+ * modified once records exist.
+ *
+ * @param fieldNames the names, in value order, shared across the source
+ * @param values     the raw values; may be shorter than {@code fieldNames} when
+ *                   the row was short
+ * @param lineNumber the line in the source, 1-based
  */
-public record RawRecordR(Map<String, String> fields, long lineNumber) implements RawRecord {
+public record RawRecordR(List<String> fieldNames, String[] values, long lineNumber) implements RawRecord {
+
+    @Override
+    public int fieldCount() {
+        return values.length;
+    }
+
+    @Override
+    public String field(int index) {
+        return index >= 0 && index < values.length ? values[index] : null;
+    }
+
+    @Override
+    public String field(String name) {
+        return field(fieldNames.indexOf(name));
+    }
+
+    @Override
+    public Map<String, String> asMap() {
+        Map<String, String> map = new LinkedHashMap<>();
+        for (int i = 0; i < fieldNames.size(); i++) {
+            map.put(fieldNames.get(i), field(i));
+        }
+        return map;
+    }
 }

--- a/model/cwm/resource.relational/src/main/java/org/eclipse/daanse/cwm/model/cwm/resource/relational/util/SqlSimpleTypes.java
+++ b/model/cwm/resource.relational/src/main/java/org/eclipse/daanse/cwm/model/cwm/resource/relational/util/SqlSimpleTypes.java
@@ -82,6 +82,21 @@ public final class SqlSimpleTypes {
         return t;
     }
 
+    // Outside Sql99 on purpose: neither type is in the CWM specification's
+    // catalogue of SQL-99 data types (section 19.5), because SQL-99 has neither.
+    // BIGINT arrived with SQL:2003; TINYINT is a vendor invention throughout.
+    //
+    // That catalogue is not a closed set. The same section says practical
+    // SQL systems vary from the types it lists and points at the product
+    // documentation, and section 19.6 names java.sql.Types as the way to
+    // identify a type uniquely — which is what the typeNumber below does.
+    //
+    // So a model may say BIGINT. How each database spells it is the dialect's
+    // business: Oracle has no BIGINT and answers ORA-00902, so its DdlGenerator
+    // renders DECIMAL(15,0) via bigintTypeName(). Putting that compromise into
+    // the model instead would bake one database into a description meant for
+    // ten.
+
     private static final SQLSimpleType BIGINT_T = Templates.integral("BIGINT", Types.BIGINT);
     private static final SQLSimpleType TINYINT_T = Templates.integral("TINYINT", Types.TINYINT);
 

--- a/resource/relational/ddl/pom.xml
+++ b/resource/relational/ddl/pom.xml
@@ -240,6 +240,10 @@
       <artifactId>junit-jupiter-params</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/resource/relational/ddl/src/main/java/org/eclipse/daanse/cwm/resource/relational/ddl/internal/DdlGeneratorImpl.java
+++ b/resource/relational/ddl/src/main/java/org/eclipse/daanse/cwm/resource/relational/ddl/internal/DdlGeneratorImpl.java
@@ -71,8 +71,23 @@ import org.eclipse.daanse.sql.dialect.api.Dialect;
  */
 public final class DdlGeneratorImpl implements DdlGenerator {
 
+    private static final org.slf4j.Logger LOGGER = org.slf4j.LoggerFactory.getLogger(DdlGeneratorImpl.class);
+
     private final Dialect dialect;
     private final DdlSettings settings;
+
+    /**
+     * Records that the dialect cannot do something the schema asks for.
+     *
+     * <p>
+     * Said out loud rather than passed over: a schema that quietly arrives with
+     * fewer entities than it describes looks exactly like a schema that was
+     * created in full, and the difference only shows up much later as a slow
+     * query or a missing constraint.
+     */
+    private void skipped(String what, String why) {
+        LOGGER.warn("db={} — {} not created: {}", dialect.name(), what, why);
+    }
 
     public DdlGeneratorImpl(Dialect dialect) {
         this(dialect, DdlSettings.defaults());
@@ -107,6 +122,10 @@ public final class DdlGeneratorImpl implements DdlGenerator {
         if (features == null || features.isEmpty()) {
             return List.of();
         }
+        // Deliberately not gated on supportsDdl(): that is derived from
+        // Connection.isReadOnly() and describes the session, not the language.
+        // A dialect built without a connection reports it as false, which would
+        // make this method silently produce nothing.
         List<String> out = new ArrayList<>();
         List<Table> tables = Schemas.tables(schema);
         List<View> views = Schemas.views(schema);
@@ -123,7 +142,10 @@ public final class DdlGeneratorImpl implements DdlGenerator {
                 if (features.contains(Feature.PRIMARY_KEY)) {
                     pkRef = primaryKeyRef(tref, table);
                 }
-                out.add(dialect.ddlGenerator().createTable(tref, cols, pkRef, settings.ifNotExists()));
+                // ifNotExists is a wish, not an instruction: a dialect without
+                // the clause would be handed SQL it cannot parse.
+                boolean ifNotExists = settings.ifNotExists() && dialect.supportsCreateTableIfNotExists();
+                out.add(dialect.ddlGenerator().createTable(tref, cols, pkRef, ifNotExists));
             }
         }
 
@@ -159,7 +181,12 @@ public final class DdlGeneratorImpl implements DdlGenerator {
             }
         }
 
-        if (features.contains(Feature.INDEX)) {
+        if (features.contains(Feature.INDEX) && !dialect.supportsIndexDdl()) {
+            // ClickHouse has said so all along; the generator wrote 96 CREATE
+            // INDEX statements at it regardless.
+            skipped("indexes", "this dialect has no CREATE INDEX");
+        } else if (features.contains(Feature.INDEX)) {
+            boolean ifNotExists = dialect.supportsCreateIndexIfNotExists();
             for (Table table : tables) {
                 TableReference tref = tableRef(schema, table, TableReference.TYPE_TABLE);
                 int idx = 0;
@@ -169,7 +196,7 @@ public final class DdlGeneratorImpl implements DdlGenerator {
                         continue;
                     }
                     String name = nameOrDefault(i, "idx_" + table.getName() + "_" + (++idx));
-                    out.add(dialect.ddlGenerator().createIndex(name, tref, colNames, i.isIsUnique(), true));
+                    out.add(dialect.ddlGenerator().createIndex(name, tref, colNames, i.isIsUnique(), ifNotExists));
                 }
             }
         }

--- a/testkit/pom.xml
+++ b/testkit/pom.xml
@@ -87,6 +87,10 @@
       <version>5.12.2</version>
       <scope>compile</scope>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
   </dependencies>
 
 </project>

--- a/testkit/src/main/java/org/eclipse/daanse/cwm/testkit/DbTiming.java
+++ b/testkit/src/main/java/org/eclipse/daanse/cwm/testkit/DbTiming.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   SmartCity Jena, Stefan Bischof - initial
+ */
+package org.eclipse.daanse.cwm.testkit;
+
+import java.util.Locale;
+
+import org.eclipse.daanse.sql.dialect.api.Dialect;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The one place that writes the timing lines a run is measured by.
+ *
+ * <pre>
+ * DBTIMING db=&lt;id&gt; phase=&lt;name&gt; ms=&lt;duration&gt; [detail=...]
+ * </pre>
+ *
+ * <p>
+ * The format is grepped by the harness collector, so it is fixed: one line per
+ * phase occurrence, fields in this order, no line breaks inside a line.
+ */
+public final class DbTiming {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DbTiming.class);
+
+    private DbTiming() {
+    }
+
+    /**
+     * Writes one line, taking the duration as now minus {@code startNanos}.
+     *
+     * <p>
+     * Logged at warn, which is not what the level means. It is what makes the
+     * line survive the default configuration of a test run, and a measurement
+     * the collector never sees is no measurement.
+     *
+     * @param detail optional trailing {@code detail=} value; omitted when null
+     */
+    public static void log(Dialect dialect, String phase, long startNanos, String detail) {
+        long ms = (System.nanoTime() - startNanos) / 1_000_000;
+        if (detail == null) {
+            LOGGER.warn("DBTIMING db={} phase={} ms={}", dbId(dialect), phase, ms);
+        } else {
+            LOGGER.warn("DBTIMING db={} phase={} ms={} detail={}", dbId(dialect), phase, ms, detail);
+        }
+    }
+
+    /**
+     * Lowercase database id, matching
+     * {@code org.eclipse.daanse.jdbc.datasource.testkit.api.DatabaseProvider#id()}
+     * so the collector can join timings to the database that produced them.
+     */
+    public static String dbId(Dialect dialect) {
+        return dialect == null || dialect.name() == null ? "unknown" : dialect.name().toLowerCase(Locale.ROOT);
+    }
+}

--- a/testkit/src/main/java/org/eclipse/daanse/cwm/testkit/api/DataSupplier.java
+++ b/testkit/src/main/java/org/eclipse/daanse/cwm/testkit/api/DataSupplier.java
@@ -42,4 +42,37 @@ public interface DataSupplier {
     default void load(Connection connection, Dialect dialect) throws Exception {
         // default: nothing
     }
+
+    /**
+     * Whether to gather optimizer statistics for {@code tableName} as soon as
+     * that table has finished loading, rather than waiting for the rest.
+     *
+     * <p>
+     * Off by default. Analysing per table is faster than one database-wide
+     * statement, but slows the loading by about as much, because both draw on the
+     * same connections and cores. It is a per-table decision because the trade
+     * depends on the dataset: one dominant table finishing early has nothing to
+     * overlap with, many mid-sized ones do.
+     *
+     * <p>
+     * A table analysed here is analysed <em>before</em> the keys and indexes
+     * exist, so the statistics cannot describe them; where that matters, rely on
+     * {@link #analyzeAfterAll()}.
+     */
+    default boolean analyzeAfterTable(String tableName) {
+        return false;
+    }
+
+    /**
+     * Whether to gather statistics for the whole database once everything is
+     * loaded and indexed. On by default: a planner with nothing to go on turns
+     * quick queries into slow ones.
+     *
+     * <p>
+     * Turn it off for a dataset small enough that the planner cannot go wrong,
+     * or when every table is already covered by {@link #analyzeAfterTable}.
+     */
+    default boolean analyzeAfterAll() {
+        return true;
+    }
 }

--- a/testkit/src/main/java/org/eclipse/daanse/cwm/testkit/data/DataLayer.java
+++ b/testkit/src/main/java/org/eclipse/daanse/cwm/testkit/data/DataLayer.java
@@ -19,13 +19,21 @@ import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.sql.Connection;
 import java.sql.JDBCType;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.Flow;
+import java.util.concurrent.Future;
+import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
@@ -39,10 +47,13 @@ import org.eclipse.daanse.cwm.model.cwm.resource.record.RecordFile;
 import org.eclipse.daanse.cwm.model.cwm.resource.relational.Column;
 import org.eclipse.daanse.cwm.model.cwm.resource.relational.Schema;
 import org.eclipse.daanse.cwm.model.cwm.resource.relational.Table;
+import org.eclipse.daanse.cwm.testkit.DbTiming;
 import org.eclipse.daanse.cwm.testkit.api.DataSupplier;
 import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.ColumnSets;
 import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.Schemas;
 import org.eclipse.daanse.sql.model.schema.SchemaReference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.eclipse.daanse.sql.model.schema.TableReference;
 import org.eclipse.daanse.sql.dialect.api.Dialect;
 import org.eclipse.daanse.cwm.data.api.RawRecord;
@@ -60,9 +71,22 @@ import org.eclipse.daanse.cwm.data.sink.jdbc.DatabaseRecordSink;
  */
 public final class DataLayer {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(DataLayer.class);
+
     private static final RecordFactory REC = RecordFactory.eINSTANCE;
-    private static final int DEFAULT_BATCH = 100;
-    private static final int CSV_LOAD_TIMEOUT_SECONDS = 60;
+
+    /**
+     * Rows per {@code executeBatch}. One table is one transaction regardless;
+     * this only decides how often the accumulated rows are sent.
+     */
+    private static final int DEFAULT_BATCH = 10_000;
+
+    /**
+     * Ceiling per table. It has to hold the largest table a dataset ships, on the
+     * slowest driver in use, so it is generous by design.
+     */
+    private static final int CSV_LOAD_TIMEOUT_SECONDS = 600;
+
 
     private DataLayer() {
     }
@@ -80,22 +104,31 @@ public final class DataLayer {
         if (csv != null && !csv.isEmpty()) {
             Path tempDir = Files.createTempDirectory("daanse-testkit-data-");
             try {
+                // Two passes. The first reads the CWM model and stages the files, on one
+                // thread, so that nothing touches EMF once the loaders are running. The
+                // second only writes, and may do so table by table in parallel.
+                List<TableLoad> loads = new ArrayList<>();
                 for (Map.Entry<String, URL> e : csv.entrySet()) {
+                    Table table = lookupTable(cwmSchema, e.getKey());
+                    if (table == null) {
+                        // The CSV is published but the CWM Schema has no table by that
+                        // name — the catalog may use a view, or the schema may not
+                        // describe this table yet. Loading is skipped, but not quietly:
+                        // a dataset that silently arrives with fewer tables than it
+                        // ships looks exactly like a dataset that loaded correctly.
+                        LOGGER.warn("no table \"{}\" in the schema — its CSV is not loaded", e.getKey());
+                        continue;
+                    }
+                    // Staged after the lookup, so a skipped CSV costs no copy.
                     Path target = tempDir.resolve(e.getKey() + ".csv");
                     try (InputStream in = e.getValue().openStream()) {
                         Files.copy(in, target, StandardCopyOption.REPLACE_EXISTING);
                     }
-                    Table table = lookupTable(cwmSchema, e.getKey());
-                    if (table == null) {
-                        // CSV is published but the CWM Schema has no table by
-                        // that name — likely the catalog uses a view or omits
-                        // this table from the physical schema. Skip silently
-                        // (the OLAP check suite will fail loudly if the table
-                        // really was required).
-                        continue;
-                    }
-                    loadCsv(dataSource, dialect, cwmSchema, table, target);
+                    loads.add(plan(cwmSchema, table, target, data.analyzeAfterTable(e.getKey())));
                 }
+                long t = System.nanoTime();
+                runLoads(dataSource, dialect, loads);
+                DbTiming.log(dialect, "csv-load", t, "tables:" + loads.size());
             } finally {
                 deleteTree(tempDir);
             }
@@ -103,6 +136,177 @@ public final class DataLayer {
         try (Connection conn = dataSource.getConnection()) {
             data.load(conn, dialect);
         }
+    }
+
+    /**
+     * Gathers optimizer statistics for the whole database, if
+     * {@link DataSupplier#analyzeAfterAll()} asks for it and the dialect has
+     * such a command. Call it <em>after</em> the indexes exist, not from inside
+     * the load: Derby's and PostgreSQL's statistics describe index
+     * cardinalities, so gathering them on an unindexed table tells the planner
+     * nothing.
+     *
+     * <p>
+     * Worth the time it takes: without statistics a planner has nothing to go on,
+     * and queries that would be quick become slow enough to reach a timeout. Only
+     * the dialects that have such a statement do anything; the rest is a no-op.
+     *
+     */
+    public static void analyze(DataSource dataSource, Dialect dialect, DataSupplier data) {
+        if (data == null || !data.analyzeAfterAll()) {
+            return;
+        }
+        List<String> sqls = analyzeSqls(dialect);
+        if (sqls.isEmpty()) {
+            return;
+        }
+        long t = System.nanoTime();
+        try (Connection connection = dataSource.getConnection(); Statement statement = connection.createStatement()) {
+            for (String sql : sqls) {
+                statement.execute(sql);
+            }
+        } catch (SQLException e) {
+            // Statistics are an optimization, never a precondition.
+            LOGGER.warn("db={} ANALYZE failed", DbTiming.dbId(dialect), e);
+            return;
+        }
+        DbTiming.log(dialect, "analyze", t, null);
+    }
+
+    /** The statement that gathers statistics, empty where the dialect has none. */
+    private static List<String> analyzeSqls(Dialect dialect) {
+        if (dialect == null) {
+            return List.of();
+        }
+        return dialect.ddlGenerator().analyzeSchema().map(List::of).orElseGet(List::of);
+    }
+
+
+    /**
+     * Gathers statistics for one table, if the dataset asked for it and the
+     * dialect has such a statement.
+     */
+    private static void analyzeTable(DataSource ds, Dialect dialect, TableReference table, boolean wanted) {
+        if (!wanted || dialect == null) {
+            return;
+        }
+        java.util.Optional<String> sql = dialect.ddlGenerator().analyzeTable(table);
+        if (sql.isEmpty()) {
+            return;
+        }
+        long t = System.nanoTime();
+        try (Connection connection = ds.getConnection(); Statement statement = connection.createStatement()) {
+            statement.execute(sql.get());
+        } catch (SQLException e) {
+            LOGGER.warn("db={} ANALYZE of {} failed", DbTiming.dbId(dialect), table.name(), e);
+            return;
+        }
+        DbTiming.log(dialect, "analyze-table", t, "table:" + table.name());
+    }
+
+
+    /**
+     * One table's load, with everything read out of the CWM model already, so the
+     * loader itself touches nothing shared.
+     */
+    private record TableLoad(String tableName, Path csvPath, TableReference tableRef, List<FieldMapping> mappings,
+            List<JDBCType> types, RecordFile recordFile, RecordDef recordDef, boolean analyzeAfterLoad) {
+    }
+
+    /**
+     * Loads the tables, in parallel where the database allows it.
+     *
+     * <p>
+     * Each table has its own connection and its own transaction, and the schema
+     * declares no foreign keys, so the order is free. What limits the gain is the
+     * largest table: it stays on the critical path however many threads run.
+     *
+     * <p>
+     * A dialect that says it takes one writer at a time gets one loader.
+     */
+    private static void runLoads(DataSource dataSource, Dialect dialect, List<TableLoad> loads) throws Exception {
+        int concurrent = Math.min(loadThreads(dialect), loads.size());
+        if (concurrent <= 1 || loads.size() <= 1) {
+            for (TableLoad load : loads) {
+                runLoad(dataSource, dialect, load);
+            }
+            return;
+        }
+        // A virtual thread per table, throttled by a permit count. The threads are
+        // free, the concurrency is not: how many loads may run at once is the one
+        // number that matters, and it stays explicit instead of being whatever the
+        // scheduler happens to allow. It also travels: against a database in a
+        // container the work is I/O-bound and the permit count can be raised at no
+        // cost, while an embedded engine reached over JNI pins its carrier anyway.
+        // Tables start in the order they were supplied - the dataset's own
+        // foreign-key order. Sorting by size first or last makes no reliable
+        // difference: with a few slots the bound is the total work, not the
+        // longest single table.
+        Semaphore permits = new Semaphore(concurrent);
+        List<Future<?>> pending = new ArrayList<>(loads.size());
+        try (ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor()) {
+            for (TableLoad load : loads) {
+                pending.add(executor.submit(() -> {
+                    permits.acquire();
+                    try {
+                        runLoad(dataSource, dialect, load);
+                        return null;
+                    } finally {
+                        permits.release();
+                    }
+                }));
+            }
+            // close() awaits every task, including the ones after a failure - which
+            // is what makes the failure list below complete.
+        }
+        List<String> failures = new ArrayList<>();
+        Throwable first = null;
+        for (int i = 0; i < pending.size(); i++) {
+            try {
+                pending.get(i).get();
+            } catch (ExecutionException e) {
+                // Collect them all: one failing table used to hide the others, and
+                // which tables failed together is usually the diagnosis.
+                failures.add(loads.get(i).tableName() + ": " + describe(e.getCause()));
+                if (first == null) {
+                    first = e.getCause();
+                }
+            }
+        }
+        if (!failures.isEmpty()) {
+            // The first failure goes on as the cause. Without it the message named
+            // the tables and swallowed the reason - "Error completing database
+            // import" three times over, with the SQLException that actually says
+            // what went wrong nowhere to be seen.
+            throw new IllegalStateException(
+                    "CSV load failed for " + failures.size() + " of " + loads.size() + " tables: " + failures, first);
+        }
+    }
+
+    /**
+     * A throwable and the chain under it, on one line. A wrapper alone says
+     * nothing: the sink's "Error completing database import" is a lid, and what
+     * matters is the {@code SQLException} beneath it.
+     */
+    private static String describe(Throwable t) {
+        StringBuilder sb = new StringBuilder();
+        for (Throwable c = t; c != null && sb.length() < 400; c = c.getCause()) {
+            if (sb.length() > 0) {
+                sb.append(" <- ");
+            }
+            sb.append(c.getClass().getSimpleName()).append(": ").append(c.getMessage());
+        }
+        return sb.toString();
+    }
+
+    private static int loadThreads(Dialect dialect) {
+        if (dialect != null && !dialect.supportsParallelLoading()) {
+            return 1;
+        }
+        // Four, not one per core. Parallel loading buys wall-clock with CPU, and
+        // past four the CPU it costs outweighs the time it saves - a caller that
+        // shares the machine with a test suite wants the CPU.
+        return 4;
     }
 
     private static Table lookupTable(Schema schema, String name) {
@@ -116,8 +320,8 @@ public final class DataLayer {
         return null;
     }
 
-    private static void loadCsv(DataSource ds, Dialect dialect, Schema schema, Table table, Path csvPath)
-            throws Exception {
+    /** Reads everything the load needs out of the CWM model. Single-threaded. */
+    private static TableLoad plan(Schema schema, Table table, Path csvPath, boolean analyzeAfterLoad) {
         RecordFile recordFile = REC.createRecordFile();
         recordFile.setIsSelfDescribing(true);
         recordFile.setSkipRecords(0);
@@ -126,10 +330,15 @@ public final class DataLayer {
         recordDef.setFieldDelimiter(",");
         recordDef.setTextDelimiter("\"");
         recordDef.setIsFixedWidth(false);
+
+        List<FieldMapping> mappings = new ArrayList<>();
+        List<JDBCType> types = new ArrayList<>();
         for (Column c : ColumnSets.columns(table)) {
             Field f = REC.createField();
             f.setName(c.getName());
             recordDef.getFeature().add(f);
+            mappings.add(new FieldMappingR(c.getName(), c.getName(), Optional.empty()));
+            types.add(jdbcTypeOf(c));
         }
 
         String schemaName = schema.getName();
@@ -138,16 +347,19 @@ public final class DataLayer {
                         : Optional.of(new SchemaReference(Optional.empty(), schemaName)),
                 table.getName(), TableReference.TYPE_TABLE);
 
-        List<FieldMapping> mappings = new ArrayList<>();
-        List<JDBCType> types = new ArrayList<>();
-        for (Column c : ColumnSets.columns(table)) {
-            mappings.add(new FieldMappingR(c.getName(), c.getName(), Optional.empty()));
-            types.add(jdbcTypeOf(c));
-        }
+        return new TableLoad(table.getName(), csvPath, tableRef, mappings, types, recordFile, recordDef,
+                analyzeAfterLoad);
+    }
 
-        DatabaseRecordSink sink = new DatabaseRecordSink(ds, dialect, tableRef, mappings, types, DEFAULT_BATCH);
-        CsvRecordPublisher publisher = new CsvRecordPublisher(csvPath, recordFile, recordDef);
+    private static void runLoad(DataSource ds, Dialect dialect, TableLoad load) throws Exception {
+        DatabaseRecordSink sink = new DatabaseRecordSink(ds, dialect, load.tableRef(), load.mappings(), load.types(),
+                DEFAULT_BATCH);
+        CsvRecordPublisher publisher = new CsvRecordPublisher(load.csvPath(), load.recordFile(), load.recordDef());
 
+        // Parsing and writing alternate on this one thread. Splitting them across
+        // two with a queue between gains nothing on one table and is 15 % worse
+        // on four: handing a row across a thread costs about what parsing it
+        // costs. Concurrency belongs between tables, not inside one.
         CountDownLatch latch = new CountDownLatch(1);
         Throwable[] error = { null };
         publisher.subscribe(new Flow.Subscriber<RawRecord>() {
@@ -175,10 +387,35 @@ public final class DataLayer {
             }
         });
         if (!latch.await(CSV_LOAD_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
-            throw new IllegalStateException("CSV load for " + table.getName() + " timed out");
+            throw new IllegalStateException("CSV load for " + load.tableName() + " timed out");
         }
         if (error[0] != null) {
-            throw new RuntimeException("CSV load failed for " + table.getName(), error[0]);
+            throw new RuntimeException("CSV load failed for " + load.tableName(), error[0]);
+        }
+        verifyRowCount(ds, dialect, load, sink.rowCount());
+        // Still inside this table's permit, so it competes with the other loads
+        // rather than waiting for all of them to finish.
+        analyzeTable(ds, dialect, load.tableRef(), load.analyzeAfterLoad());
+    }
+
+    /**
+     * Reads back what the load claims to have written. The sink counts the rows
+     * it bound, not the rows the database stored, so without this a table can be
+     * reported as loaded while it holds nothing — which is exactly how four
+     * tables once went missing without a single failing test.
+     */
+    private static void verifyRowCount(DataSource ds, Dialect dialect, TableLoad load, long expected)
+            throws SQLException {
+        String sql = "SELECT count(*) FROM " + dialect.ddlGenerator().qualified(load.tableRef());
+        long actual;
+        try (Connection connection = ds.getConnection();
+                Statement statement = connection.createStatement();
+                ResultSet rs = statement.executeQuery(sql)) {
+            actual = rs.next() ? rs.getLong(1) : -1;
+        }
+        if (actual != expected) {
+            throw new IllegalStateException(load.tableName() + ": loaded " + expected
+                    + " rows but the table holds " + actual);
         }
     }
 

--- a/testkit/src/main/java/org/eclipse/daanse/cwm/testkit/database/DatabaseLayer.java
+++ b/testkit/src/main/java/org/eclipse/daanse/cwm/testkit/database/DatabaseLayer.java
@@ -15,12 +15,19 @@ package org.eclipse.daanse.cwm.testkit.database;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.ServiceLoader;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.Semaphore;
 
 import javax.sql.DataSource;
 
+import org.eclipse.daanse.cwm.testkit.DbTiming;
 import org.eclipse.daanse.cwm.resource.relational.ddl.api.DdlGeneratorFactory;
 import org.eclipse.daanse.cwm.resource.relational.ddl.api.DdlSettings;
 import org.eclipse.daanse.cwm.resource.relational.ddl.api.Feature;
@@ -65,10 +72,133 @@ public final class DatabaseLayer {
         if (ddl.isEmpty()) {
             return;
         }
-        try (Connection conn = dataSource.getConnection(); Statement stmt = conn.createStatement()) {
+        long t = System.nanoTime();
+        execute(dataSource, dialect, ddl);
+        // Two calls are the normal shape - tables before the data, keys and
+        // indexes after it - so the phase says which of the two this was.
+        DbTiming.log(dialect, features.contains(Feature.TABLE) ? "ddl" : "index", t, "statements:" + ddl.size());
+    }
+
+    /**
+     * Runs the generated DDL, statements of the same concurrent kind in
+     * parallel. Each is a round trip the server spends mostly waiting, so
+     * overlapping them shortens the schema build against a remote database and
+     * costs nothing against an embedded one.
+     *
+     * <p>
+     * Kinds never mix, so the generator's order survives — indexes still follow
+     * the tables they are on.
+     *
+     * <p>
+     * Within a concurrent run each statement gets its own connection: a JDBC
+     * connection need not be thread-safe, and an embedded engine refuses a second
+     * statement while one is pending on the same connection. Everything outside
+     * such a run is sequential and shares one connection, so a schema does not
+     * open a session per statement.
+     */
+    private static void execute(DataSource dataSource, Dialect dialect, List<String> ddl) throws SQLException {
+        int concurrent = concurrentDdl(dialect);
+        List<String> run = new ArrayList<>();
+        String runKind = null;
+        try (Connection connection = dataSource.getConnection(); Statement statement = connection.createStatement()) {
             for (String sql : ddl) {
-                stmt.execute(sql);
+                String kind = concurrentKind(sql);
+                if (kind != null) {
+                    // Only statements of the same kind share a run, so the order
+                    // between kinds survives — indexes still come after the
+                    // tables they are on.
+                    if (runKind != null && !runKind.equals(kind)) {
+                        executeRun(dataSource, run, concurrent);
+                        run.clear();
+                    }
+                    runKind = kind;
+                    run.add(sql);
+                    continue;
+                }
+                // The concurrent run finishes before the shared connection is
+                // used again, so the two never overlap.
+                executeRun(dataSource, run, concurrent);
+                run.clear();
+                runKind = null;
+                statement.execute(sql);
+            }
+            executeRun(dataSource, run, concurrent);
+        }
+    }
+
+    /**
+     * The kind of a statement that may run beside its own kind, or null for one
+     * that must wait its turn. Tables and indexes qualify: within either kind the
+     * statements are independent. Indexes on one table do contend on the server,
+     * but a schema spreads them over many.
+     */
+    private static String concurrentKind(String sql) {
+        if (sql == null) {
+            return null;
+        }
+        String s = sql.stripLeading();
+        if (s.regionMatches(true, 0, "CREATE TABLE", 0, "CREATE TABLE".length())) {
+            return "TABLE";
+        }
+        if (s.regionMatches(true, 0, "CREATE INDEX", 0, "CREATE INDEX".length())
+                || s.regionMatches(true, 0, "CREATE UNIQUE INDEX", 0, "CREATE UNIQUE INDEX".length())) {
+            return "INDEX";
+        }
+        return null;
+    }
+
+    private static void executeRun(DataSource dataSource, List<String> run, int concurrent) throws SQLException {
+        if (run.isEmpty()) {
+            return;
+        }
+        if (concurrent <= 1 || run.size() == 1) {
+            for (String sql : run) {
+                executeOne(dataSource, sql);
+            }
+            return;
+        }
+        Semaphore permits = new Semaphore(concurrent);
+        List<String> statements = List.copyOf(run);
+        List<Future<?>> pending = new ArrayList<>(statements.size());
+        try (ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor()) {
+            for (String sql : statements) {
+                pending.add(executor.submit(() -> {
+                    permits.acquire();
+                    try {
+                        executeOne(dataSource, sql);
+                        return null;
+                    } finally {
+                        permits.release();
+                    }
+                }));
             }
         }
+        for (int i = 0; i < pending.size(); i++) {
+            try {
+                pending.get(i).get();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new SQLException("interrupted while creating tables", e);
+            } catch (ExecutionException e) {
+                throw new SQLException("DDL failed: " + statements.get(i), e.getCause());
+            }
+        }
+    }
+
+    private static void executeOne(DataSource dataSource, String sql) throws SQLException {
+        try (Connection conn = dataSource.getConnection(); Statement stmt = conn.createStatement()) {
+            stmt.execute(sql);
+        }
+    }
+
+    /** Statements of one kind that may run at once; a single-writer dialect gets one. */
+    private static final int CONCURRENT_DDL = 4;
+
+    /** How many statements of one kind may run at once. */
+    private static int concurrentDdl(Dialect dialect) {
+        if (dialect != null && !dialect.supportsParallelLoading()) {
+            return 1;
+        }
+        return CONCURRENT_DDL;
     }
 }


### PR DESCRIPTION
DatabaseLayer creates a schema from a CWM Schema, feature by feature, and asks the dialect before emitting each: a database with no CREATE INDEX gets none, and what is left out is logged rather than passed over. Table and index statements of one kind run concurrently.

DataLayer loads the CSVs, verifies the row count per table, and gathers optimizer statistics where the dialect has a statement for it. Loading runs in parallel unless the dialect says it takes one writer.

CsvRecordPublisher rejects a row whose field count differs from the header instead of padding it. RawRecord exposes field names and positions so a consumer resolves them once rather than per row. The JDBC sink writes several tuples per statement, binds nulls with a type code, and binds booleans as numbers where the dialect stores them that way.

DbTiming writes one DBTIMING line per phase.
